### PR TITLE
Add web push channel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,3 @@
+preset: laravel
+
+linting: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All Notable changes to `:package_name` will be documented in this file
+
+## 1.0.0 - 201X-XX-XX
+
+- initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+Please read and understand the contribution guide before creating an issue or pull request.
+
+## Etiquette
+
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
+
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+**Happy coding**!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) Cretu Eusebiu <me@cretueusebiu.com>
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,118 @@
-# new-channels
-Submit pull requests here for new notification channels
+# Web push notifications channel for Laravel 5.3
+
+## Installation
+
+You can install the package via composer:
+
+``` bash
+composer require laravel-notification-channels/web-push-notifications
+```
+
+First you must install the service provider:
+
+``` php
+// config/app.php
+'providers' => [
+    ...
+    NotificationChannels\WebPushNotifications\Provider::class,
+];
+```
+
+Then configure [Google Cloud Messaging](https://console.cloud.google.com) by setting your `key` and `sender_id`:
+
+``` php
+'gcm' => [
+    'key' => '',
+    'sender_id' => ',
+],
+```
+
+You need to add the `NotificationChannels\WebPushNotifications\HasPushSubscriptions` in your `User` model:
+
+``` php
+use NotificationChannels\WebPushNotifications\HasPushSubscriptions;
+
+class User extends Model
+{
+    use HasPushSubscriptions;
+}
+```
+
+Next publish the migration with:
+
+``` bash
+php artisan vendor:publish --provider="NotificationChannels\WebPushNotifications\Provider" --tag="migrations"
+```
+
+After the migration has been published you can create the `push_subscriptions` table by running the migrations:
+
+``` bash
+php artisan migrate
+```
+
+## Usage
+
+Now you can use the channel in your `via()` method inside the notification as well as send a web push notification:
+
+``` php
+use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPushNotifications\Message;
+use NotificationChannels\WebPushNotifications\Channel as WebPushChannel;
+
+class AccountApproved extends Notification
+{
+    public function via($notifiable)
+    {
+        return [WebPushChannel::class];
+    }
+
+    public function toWebPush($notifiable, $notification)
+    {
+        return (new WebPushMessage())
+            // ->id($notification->id)
+            ->title('Approved!')
+            ->icon('/approved-icon.png')
+            ->body('Your account was approved!')
+            ->action('View account', 'view_account');
+    }
+}
+```
+
+### Save/Update Subscriptions
+
+To save or update a subscription use the `updatePushSubscription($endpoint, $key = null, $token = null)` method on your user:
+
+``` php
+$user = \App\User::find(1);
+
+$user->updatePushSubscription($endpoint, $key, $token);
+```
+
+The `$key` and `$token` are optional and are used to encrypt your notifications. Only encrypted notifications can have a payload.
+
+### Delete Subscriptions
+
+To delete a subscription use the `deleteSubscription($endpoint)` method on your user:
+
+``` php
+$user = \App\User::find(1);
+
+$user->deleteSubscription($endpoint);
+```
+
+## Demo
+
+For a complete implementation with a Service Worker check this [demo](https://github.com/cretueusebiu/laravel-web-push-demo). 
+
+## Browser Compatibility
+
+The [Push API](https://developer.mozilla.org/en/docs/Web/API/Push_API) currently works on Chrome and Firefox.
+
+## Credits
+
+- [Cretu Eusebiu](https://github.com/cretueusebiu)
+- [All Contributors](../../contributors)
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "laravel-notification-channels/web-push-notifications",
+    "description": "Web Push Notifications driver for Laravel.",
+    "homepage": "https://github.com/laravel-notification-channels/web-push-notifications",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Cretu Eusebiu",
+            "email": "me@cretueusebiu.com",
+            "homepage": "http://cretueusebiu.com",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=5.6.4",
+        "illuminate/notifications": "^5.3@dev",
+        "illuminate/support": "^5.3@dev",
+        "illuminate/events": "^5.3@dev",
+        "minishlink/web-push": "^1.1"
+    },
+    "require-dev": {
+        "mockery/mockery": "^0.9.5",
+        "phpunit/phpunit": "4.*"
+    },
+    "autoload": {
+        "psr-4": {
+            "NotificationChannels\\WebPushNotifications\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NotificationChannels\\:WebPushNotifications\\Test\\": "tests"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev"
+}

--- a/migrations/create_push_subscriptions_table.php.stub
+++ b/migrations/create_push_subscriptions_table.php.stub
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePushSubscriptionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('push_subscriptions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->unsigned()->index();
+            $table->string('endpoint')->unique();
+            $table->string('public_key')->nullable();
+            $table->string('auth_token')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                    ->references('id')
+                    ->on('users')
+                    ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('push_subscriptions');
+    }
+}

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace NotificationChannels\WebPushNotifications;
+
+use Minishlink\WebPush\WebPush;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPushNotifications\Events\MessageWasSent;
+use NotificationChannels\WebPushNotifications\Events\SendingMessage;
+
+class Channel
+{
+    /**
+     * @var \Minishlink\WebPush\WebPush
+     */
+    protected $webPush;
+
+    /**
+     * Create a new Web Push channel instance.
+     *
+     * @param  \Minishlink\WebPush\WebPush $webPush
+     * @return void
+     */
+    public function __construct(WebPush $webPush)
+    {
+        $this->webPush = $webPush;
+    }
+
+    /**
+     * Send the given notification.
+     *
+     * @param  mixed $notifiable
+     * @param  \Illuminate\Notifications\Notification $notification
+     * @return void
+     */
+    public function send($notifiable, Notification $notification)
+    {
+        $shouldSendMessage = event(new SendingMessage($notifiable, $notification), [], true) !== false;
+
+        if (! $shouldSendMessage) {
+            return;
+        }
+
+        $subscriptions = $notifiable->routeNotificationFor('WebPushNotifications');
+
+        if ($subscriptions->isEmpty()) {
+            return;
+        }
+
+        $payload = json_encode($notification->toWebPush($notifiable, $notification)->toArray());
+
+        $subscriptions->each(function ($sub) use ($payload) {
+            $this->webPush->sendNotification(
+                $sub->endpoint,
+                $payload,
+                $sub->public_key,
+                $sub->auth_token
+            );
+        });
+
+        $response = $this->webPush->flush();
+
+        // Delete the invalid subscriptions.
+        if (is_array($response)) {
+            foreach ($response as $index => $value) {
+                if (! $value['success'] && isset($subscriptions[$index])) {
+                    $subscriptions[$index]->delete();
+                }
+            }
+        }
+
+        event(new MessageWasSent($notifiable, $notification));
+    }
+}

--- a/src/Events/MessageWasSent.php
+++ b/src/Events/MessageWasSent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace NotificationChannels\WebPushNotifications\Events;
+
+use Illuminate\Notifications\Notification;
+
+class MessageWasSent
+{
+    protected $notifiable;
+
+    /** @var \Illuminate\Notifications\Notification */
+    protected $notification;
+
+    /**
+     * @param $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     */
+    public function __construct($notifiable, Notification $notification)
+    {
+        $this->notifiable = $notifiable;
+
+        $this->notification = $notification;
+    }
+}

--- a/src/Events/SendingMessage.php
+++ b/src/Events/SendingMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace NotificationChannels\WebPushNotifications\Events;
+
+use Illuminate\Notifications\Notification;
+
+class SendingMessage
+{
+
+    protected $notifiable;
+
+    /** @var \Illuminate\Notifications\Notification */
+    protected $notification;
+
+    /**
+     * @param $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     */
+    public function __construct($notifiable, Notification $notification)
+    {
+        $this->notifiable = $notifiable;
+
+        $this->notification = $notification;
+    }
+}

--- a/src/HasPushSubscriptions.php
+++ b/src/HasPushSubscriptions.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace NotificationChannels\WebPushNotifications;
+
+trait HasPushSubscriptions
+{
+    /**
+     * Get the user's push subscriptions.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function pushSubscriptions()
+    {
+        return $this->hasMany(PushSubscription::class);
+    }
+
+    /**
+     * Update (or create) user subscription.
+     *
+     * @param  string $endpoint
+     * @param  string|null $key
+     * @param  string|null $token
+     * @return \Eusebiu\WebPush\PushSubscription
+     */
+    public function updatePushSubscription($endpoint, $key = null, $token = null)
+    {
+        $subscription = PushSubscription::findByEndpoint($endpoint);
+
+        // Check if a subscription exists for the given endpoint.
+        if ($subscription) {
+            // If it belongs to a different user then delete it.
+            if ((int) $subscription->user_id !== (int) $this->getAuthIdentifier()) {
+                $subscription->delete();
+            }
+            // Otherwise update the public key and auth token.
+            else {
+                $subscription->public_key = $key;
+                $subscription->auth_token = $token;
+                $subscription->save();
+
+                return $subscription;
+            }
+        }
+
+        // Just create a new subscription.
+        return $this->pushSubscriptions()->save(new PushSubscription([
+            'endpoint' => $endpoint,
+            'public_key' => $key,
+            'auth_token' => $token,
+        ]));
+    }
+
+    /**
+     * Delete subscription by endpoint.
+     *
+     * @param  string $endpoint
+     * @return void
+     */
+    public function deleteSubscription($endpoint)
+    {
+        $this->pushSubscriptions()
+                ->where('endpoint', $endpoint)
+                ->delete();
+    }
+
+    /**
+     * Get all subscriptions.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function routeNotificationForWebPushNotifications()
+    {
+        return $this->pushSubscriptions;
+    }
+}

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace NotificationChannels\WebPushNotifications;
+
+use Illuminate\Support\Arr;
+
+class Message
+{
+    /**
+     * The notification id.
+     *
+     * @var string
+     */
+    protected $id = null;
+
+    /**
+     * The notification title.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * The notification body.
+     *
+     * @var string
+     */
+    protected $body;
+
+    /**
+     * The notification icon.
+     *
+     * @var string
+     */
+    protected $icon = null;
+
+    /**
+     * The notification actions.
+     *
+     * @var array
+     */
+    protected $actions = [];
+
+    /**
+     * @param string $title
+     * @param string $body
+     */
+    public function __construct($title = '', $body = '')
+    {
+        $this->title = $title;
+        $this->body = $body;
+    }
+
+    /**
+     * Set the notification id.
+     *
+     * @param  string $value
+     * @return $this
+     */
+    public function id($value)
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the notification title.
+     *
+     * @param  string $value
+     * @return $this
+     */
+    public function title($value)
+    {
+        $this->title = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the notification body.
+     *
+     * @param  string $value
+     * @return $this
+     */
+    public function body($value)
+    {
+        $this->body = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the notification icon.
+     *
+     * @param  string $value
+     * @return $this
+     */
+    public function icon($value)
+    {
+        $this->icon = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set an action.
+     *
+     * @param  string $title
+     * @param  string $action
+     * @return $this
+     */
+    public function action($title, $action)
+    {
+        $this->actions[] = compact('title', 'action');
+
+        return $this;
+    }
+
+    /**
+     * Get an array representation of the message.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'body' => $this->body,
+            'actions' => $this->actions,
+            'icon' => $this->icon,
+        ];
+    }
+}

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace NotificationChannels\WebPushNotifications;
+
+use Minishlink\WebPush\WebPush;
+use Illuminate\Support\ServiceProvider;
+
+class Provider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->app->when(Channel::class)
+            ->needs(WebPush::class)
+            ->give(function () {
+                return new WebPush([
+                    'GCM' => config('services.gcm.key')
+                ]);
+            });
+
+        if ($this->app->runningInConsole()) {
+            $this->definePublishing();
+        }
+    }
+
+    /**
+     * Define the publishable migrations and resources.
+     *
+     * @return void
+     */
+    protected function definePublishing()
+    {
+        if (! class_exists('CreatePushSubscriptionsTable')) {
+            $timestamp = date('Y_m_d_His', time());
+
+            $this->publishes([
+                __DIR__.'/../migrations/create_push_subscriptions_table.php.stub' =>
+                    $this->app->databasePath().'/migrations/'.$timestamp.'_create_push_subscriptions_table.php',
+            ], 'migrations');
+        }
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+}

--- a/src/PushSubscription.php
+++ b/src/PushSubscription.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace NotificationChannels\WebPushNotifications;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Database\Eloquent\Model;
+
+class PushSubscription extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'endpoint',
+        'public_key',
+        'auth_token',
+    ];
+
+    /**
+     * Get the user that owns the subscription.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function user()
+    {
+        return $this->belongsTo(Config::get('auth.providers.users.model'));
+    }
+
+    /**
+     * Find a subscription by the given endpint.
+     *
+     * @param  string $endpoint
+     * @return static|null
+     */
+    public static function findByEndpoint($endpoint)
+    {
+        return static::where('endpoint', $endpoint)->first();
+    }
+}


### PR DESCRIPTION
This PR adds a channel for sending Web Push Notifications with GCM (on Google Chrome) and Mozilla Push Service (on Firefox).

A demo of this new channel can be found here:
https://github.com/cretueusebiu/laravel-web-push-demo

![Demo](http://i.imgur.com/3QmEeVl.gif)
