### PR TITLE
Add Pusher API Notifications channel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+build
 vendor
 composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,3 @@
+preset: laravel
+
+linting: true

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+
+env:
+  matrix:
+    - COMPOSER_FLAGS="--prefer-lowest"
+    - COMPOSER_FLAGS=""
+
+before_script:
+  - travis_retry composer update ${COMPOSER_FLAGS}
+
+script:
+  - vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 All notable changes to `pusher-api-notifications` will be documented in this file
 
-## 1.0.0 - 201X-XX-XX
+## 1.0.0 - 2019-03-19
 
--   initial release
+-   Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to `pusher-api-notifications` will be documented in this file
+
+## 1.0.0 - 201X-XX-XX
+
+-   initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+Please read and understand the contribution guide before creating an issue or pull request.
+
+## Etiquette
+
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
+
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+**Happy coding**!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) Andrés Herrera García <andreshg112@gmail.com>
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-Use this repo as a skeleton for your new channel, once you're done please submit a Pull Request on [this repo](https://github.com/laravel-notification-channels/new-channels) with all the files.
-
-Here's the latest documentation on Laravel 5.3 Notifications System:
-
-https://laravel.com/docs/master/notifications
-
-# A Boilerplate repo for contributions
+# Pusher API Notifications
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-api-notifications)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
@@ -17,14 +11,9 @@ https://laravel.com/docs/master/notifications
 
 This package makes it easy to send notifications using [Pusher API Notifications](https://pusher.com) with Laravel 5.3 or greater.
 
-**Note:** Replace `PusherApiNotifications` `Pusher API Notifications` `Andrés Herrera García` `andreshg112` `https://github.com/andreshg112` `andreshg112@gmail.com` `pusher-api-notifications` `Send Pusher API Notifications` `175997406` `1b3c70de-4b10-4f3d-8a27-edd150e64193` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md), [composer.json](composer.json) and other files, then delete this line.
-**Tip:** Use "Find in Path/Files" in your code editor to find these keywords within the package directory and replace all occurences with your specified term.
-
-This is where your description should go. Add a little code example so build can understand real quick how the package can be used. Try and limit it to a paragraph or two.
-
 ## Contents
 
--   [Installation](#installation) - [Setting up the Pusher API Notifications service](#setting-up-the-Pusher API Notifications-service)
+-   [Installation](#installation) - [Setting up the Pusher API Notifications service](#setting-up-the-Pusher-API-Notifications-service)
 -   [Usage](#usage) - [Available Message methods](#available-message-methods)
 -   [Changelog](#changelog)
 -   [Testing](#testing)
@@ -35,19 +24,76 @@ This is where your description should go. Add a little code example so build can
 
 ## Installation
 
-Please also include the steps for any third-party service setup that's required for this package.
+> While this is not accepted in [Laravel Notification Channels](http://laravel-notification-channels.com/) and added to [Packagist](http://packagist.org), you have to add this in your `composer.json` file:
+
+```json
+{
+    ...,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/andreshg112/pusher-api-notifications.git"
+        }
+    ]
+}
+```
+
+Require the package:
+
+```bash
+$ composer require laravel-notification-channels/pusher-api-notifications
+```
 
 ### Setting up the Pusher API Notifications service
 
-Optionally include a few steps how users can set up the service.
+This package requires [pusher/pusher-http-laravel ^4.2](https://github.com/pusher/pusher-http-laravel), so after installing this, you have to [configure it](https://github.com/pusher/pusher-http-laravel#configuration).
 
 ## Usage
 
-Some code examples, make it clear how to use the package
+> This is a third-party Laravel Notification Package, so you should know how to use Notifications in Laravel before using this. Docs can be found here: https://laravel.com/docs/master/notifications.
+
+In your notification, add the `PusherApiChannel` to the `via()` function:
+
+```php
+use NotificationChannels\PusherApiNotifications\PusherApiChannel;
+
+public function via($notifiable)
+{
+    return [PusherApiChannel::class];
+}
+```
+
+Then, create a method called `toApiNotification()` in your notification:
+
+```php
+use NotificationChannels\PusherApiNotifications\PusherApiMessage;
+
+public function toApiNotification($notifiable)
+{
+    return (new PusherApiMessage)
+        ->channels($channelName)
+        ->event($eventName)
+        ->data($data)
+        ->socketId($socketId)
+        ->debug($debug)
+        ->alreadyEncoded($alreadyEncoded);
+
+    // or
+
+    return new PusherApiMessage($channelName, $eventName, $data, $socketId, $debug, $alreadyEncoded);
+}
+```
 
 ### Available Message methods
 
-A list of all available options
+-   `channels($channelName)`: array or string of channel name(s).
+-   `event($eventName)`: the name of the event for the Pusher message.
+-   `data($data)`: array, string or something that can be corverted to JSON. It's the body of the Pusher message.
+-   `socketId($socketId)`: [optional] socketId of Pusher.
+-   `debug($debug)`: boolean that tells Pusher if you're debugging.
+-   `alreadyEncoded($alreadyEncoded)`: [optional] If the data is already encoded and you don't want Pusher to convert it, set this tu true.
+
+These parameters are the same received by [`Pusher::trigger()` method](https://github.com/pusher/pusher-http-laravel#examples).
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This package makes it easy to send notifications using [Pusher API Notifications
 
 ```json
 {
-    ...,
+    // ...,
     "repositories": [
         {
             "type": "vcs",
@@ -100,9 +100,9 @@ public function toApiNotification($notifiable)
 -   `data($data)`: array, string or something that can be corverted to JSON. It's the body of the Pusher message.
 -   `socketId($socketId)`: [optional] socketId of Pusher.
 -   `debug($debug)`: boolean that tells Pusher if you're debugging.
--   `alreadyEncoded($alreadyEncoded)`: [optional] If the data is already encoded and you don't want Pusher to convert it, set this tu true.
+-   `alreadyEncoded($alreadyEncoded)`: [optional] If the data is already encoded and you don't want Pusher to convert it, set this to true.
 
-These parameters are the same received by [`Pusher::trigger()` method](https://github.com/pusher/pusher-http-laravel#examples).
+These parameters are the same received by [`Pusher::trigger()`](https://github.com/pusher/pusher-http-laravel#examples) method.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This package makes it easy to send notifications using [Pusher API Notifications
 
 ```json
 {
-    // ...,
     "repositories": [
         {
             "type": "vcs",
@@ -99,7 +98,7 @@ public function toApiNotification($notifiable)
 -   `event($eventName)`: the name of the event for the Pusher message.
 -   `data($data)`: array, string or something that can be corverted to JSON. It's the body of the Pusher message.
 -   `socketId($socketId)`: [optional] socketId of Pusher.
--   `debug($debug)`: boolean that tells Pusher if you're debugging.
+-   `debug($debug)`: [optional] boolean that tells Pusher if you're debugging.
 -   `alreadyEncoded($alreadyEncoded)`: [optional] If the data is already encoded and you don't want Pusher to convert it, set this to true.
 
 These parameters are the same received by [`Pusher::trigger()`](https://github.com/pusher/pusher-http-laravel#examples) method.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+Use this repo as a skeleton for your new channel, once you're done please submit a Pull Request on [this repo](https://github.com/laravel-notification-channels/new-channels) with all the files.
+
+Here's the latest documentation on Laravel 5.3 Notifications System:
+
+https://laravel.com/docs/master/notifications
+
+# A Boilerplate repo for contributions
+
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-api-notifications)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://img.shields.io/travis/laravel-notification-channels/pusher-api-notifications/master.svg?style=flat-square)](https://travis-ci.org/laravel-notification-channels/pusher-api-notifications)
+[![StyleCI](https://styleci.io/repos/:style_ci_id/shield)](https://styleci.io/repos/:style_ci_id)
+[![SensioLabsInsight](https://img.shields.io/sensiolabs/i/:sensio_labs_id.svg?style=flat-square)](https://insight.sensiolabs.com/projects/:sensio_labs_id)
+[![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/pusher-api-notifications)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/pusher-api-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/pusher-api-notifications/?branch=master)
+[![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-api-notifications)
+
+This package makes it easy to send notifications using [Pusher API Notifications](link to service) with Laravel 5.3.
+
+**Note:** Replace `PusherApiNotifications` `Pusher API Notifications` `Andrés Herrera García` `andreshg112` `https://github.com/andreshg112` `andreshg112@gmail.com` `pusher-api-notifications` `Send Pusher API Notifications` `:style_ci_id` `:sensio_labs_id` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md), [composer.json](composer.json) and other files, then delete this line.
+**Tip:** Use "Find in Path/Files" in your code editor to find these keywords within the package directory and replace all occurences with your specified term.
+
+This is where your description should go. Add a little code example so build can understand real quick how the package can be used. Try and limit it to a paragraph or two.
+
+## Contents
+
+-   [Installation](#installation) - [Setting up the Pusher API Notifications service](#setting-up-the-Pusher API Notifications-service)
+-   [Usage](#usage) - [Available Message methods](#available-message-methods)
+-   [Changelog](#changelog)
+-   [Testing](#testing)
+-   [Security](#security)
+-   [Contributing](#contributing)
+-   [Credits](#credits)
+-   [License](#license)
+
+## Installation
+
+Please also include the steps for any third-party service setup that's required for this package.
+
+### Setting up the Pusher API Notifications service
+
+Optionally include a few steps how users can set up the service.
+
+## Usage
+
+Some code examples, make it clear how to use the package
+
+### Available Message methods
+
+A list of all available options
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+
+## Testing
+
+```bash
+$ composer test
+```
+
+## Security
+
+If you discover any security related issues, please email andreshg112@gmail.com instead of using the issue tracker.
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+## Credits
+
+-   [Andrés Herrera García](https://github.com/andreshg112)
+-   [All Contributors](../../contributors)
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/andreshg112/pusher-api-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/andreshg112/pusher-api-notifications/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-api-notifications)
 
-This package makes it easy to send notifications using [Pusher API Notifications](https://pusher.com) with Laravel 5.3 or greater.
+This package makes it easy to send notifications using [Pusher API Notifications](https://pusher.com/docs/javascript_quick_start) with Laravel 5.3 or greater.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ $ composer require laravel-notification-channels/pusher-api-notifications
 
 This package requires [pusher/pusher-http-laravel ^4.2](https://github.com/pusher/pusher-http-laravel), so after installing this, you have to [configure it](https://github.com/pusher/pusher-http-laravel#configuration).
 
+> If your using Laravel ^5.5, don't worry about adding the service provider to your `config/app.php` file because this package uses [Laravel Package Discovery](https://laravel.com/docs/5.8/packages#package-discovery). If don't, you have to add it:
+
+```php
+'providers' => [
+    // ...,
+    NotificationChannels\PusherApiNotifications\PusherApiServiceProvider::class,
+],
+```
+
 ## Usage
 
 > This is a third-party Laravel Notification Package, so you should know how to use Notifications in Laravel before using this. Docs can be found here: https://laravel.com/docs/master/notifications.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ https://laravel.com/docs/master/notifications
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-api-notifications)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/travis/laravel-notification-channels/pusher-api-notifications/master.svg?style=flat-square)](https://travis-ci.org/laravel-notification-channels/pusher-api-notifications)
+[![Build Status](https://travis-ci.com/andreshg112/pusher-api-notifications.svg?branch=master)](https://travis-ci.com/andreshg112/pusher-api-notifications)
 [![StyleCI](https://styleci.io/repos/175997406/shield)](https://styleci.io/repos/175997406)
-[![SensioLabsInsight](https://img.shields.io/sensiolabs/i/:sensio_labs_id.svg?style=flat-square)](https://insight.sensiolabs.com/projects/:sensio_labs_id)
-[![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/pusher-api-notifications)
-[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/pusher-api-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/pusher-api-notifications/?branch=master)
+[![SensioLabsInsight](https://insight.symfony.com/projects/1b3c70de-4b10-4f3d-8a27-edd150e64193/mini.svg)](https://insight.symfony.com/projects/1b3c70de-4b10-4f3d-8a27-edd150e64193)
+[![Quality Score](https://img.shields.io/scrutinizer/g/andreshg112/pusher-api-notifications.svg?style=flat-square)](https://scrutinizer-ci.com/g/andreshg112/pusher-api-notifications)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/andreshg112/pusher-api-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/andreshg112/pusher-api-notifications/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-api-notifications)
 
-This package makes it easy to send notifications using [Pusher API Notifications](link to service) with Laravel 5.3.
+This package makes it easy to send notifications using [Pusher API Notifications](https://pusher.com) with Laravel 5.3 or greater.
 
-**Note:** Replace `PusherApiNotifications` `Pusher API Notifications` `Andrés Herrera García` `andreshg112` `https://github.com/andreshg112` `andreshg112@gmail.com` `pusher-api-notifications` `Send Pusher API Notifications` `175997406` `:sensio_labs_id` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md), [composer.json](composer.json) and other files, then delete this line.
+**Note:** Replace `PusherApiNotifications` `Pusher API Notifications` `Andrés Herrera García` `andreshg112` `https://github.com/andreshg112` `andreshg112@gmail.com` `pusher-api-notifications` `Send Pusher API Notifications` `175997406` `1b3c70de-4b10-4f3d-8a27-edd150e64193` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md), [composer.json](composer.json) and other files, then delete this line.
 **Tip:** Use "Find in Path/Files" in your code editor to find these keywords within the package directory and replace all occurences with your specified term.
 
 This is where your description should go. Add a little code example so build can understand real quick how the package can be used. Try and limit it to a paragraph or two.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://laravel.com/docs/master/notifications
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-api-notifications)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/laravel-notification-channels/pusher-api-notifications/master.svg?style=flat-square)](https://travis-ci.org/laravel-notification-channels/pusher-api-notifications)
-[![StyleCI](https://styleci.io/repos/:style_ci_id/shield)](https://styleci.io/repos/:style_ci_id)
+[![StyleCI](https://styleci.io/repos/175997406/shield)](https://styleci.io/repos/175997406)
 [![SensioLabsInsight](https://img.shields.io/sensiolabs/i/:sensio_labs_id.svg?style=flat-square)](https://insight.sensiolabs.com/projects/:sensio_labs_id)
 [![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/pusher-api-notifications.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/pusher-api-notifications)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/pusher-api-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/pusher-api-notifications/?branch=master)
@@ -17,7 +17,7 @@ https://laravel.com/docs/master/notifications
 
 This package makes it easy to send notifications using [Pusher API Notifications](link to service) with Laravel 5.3.
 
-**Note:** Replace `PusherApiNotifications` `Pusher API Notifications` `Andrés Herrera García` `andreshg112` `https://github.com/andreshg112` `andreshg112@gmail.com` `pusher-api-notifications` `Send Pusher API Notifications` `:style_ci_id` `:sensio_labs_id` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md), [composer.json](composer.json) and other files, then delete this line.
+**Note:** Replace `PusherApiNotifications` `Pusher API Notifications` `Andrés Herrera García` `andreshg112` `https://github.com/andreshg112` `andreshg112@gmail.com` `pusher-api-notifications` `Send Pusher API Notifications` `175997406` `:sensio_labs_id` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md), [composer.json](composer.json) and other files, then delete this line.
 **Tip:** Use "Find in Path/Files" in your code editor to find these keywords within the package directory and replace all occurences with your specified term.
 
 This is where your description should go. Add a little code example so build can understand real quick how the package can be used. Try and limit it to a paragraph or two.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,12 @@
 {
     "name": "laravel-notification-channels/pusher-api-notifications",
     "description": "Send Pusher API Notifications",
+    "keywords": [
+        "pusher-api-notifications",
+        "laravel",
+        "pusher",
+        "notifications"
+    ],
     "homepage": "https://github.com/laravel-notification-channels/pusher-api-notifications",
     "license": "MIT",
     "authors": [
@@ -12,14 +18,15 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.0.0",
         "illuminate/notifications": "^5.3",
         "illuminate/support": "^5.1|^5.2|^5.3",
         "pusher/pusher-http-laravel": "^4.2"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "4.*"
+        "mockery/mockery": "^1.2",
+        "orchestra/testbench": "~3.0",
+        "phpunit/phpunit": "^7.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": ">=5.6.4",
         "illuminate/notifications": "^5.3",
-        "illuminate/support": "^5.1|^5.2|^5.3"
+        "illuminate/support": "^5.1|^5.2|^5.3",
+        "pusher/pusher-http-laravel": "^4.2"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
@@ -35,5 +36,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "NotificationChannels\\PusherApiNotifications\\PusherApiServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "laravel-notification-channels/pusher-api-notifications",
+    "description": "Send Pusher API Notifications",
+    "homepage": "https://github.com/laravel-notification-channels/pusher-api-notifications",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Andrés Herrera García",
+            "email": "andreshg112@gmail.com",
+            "homepage": "https://github.com/andreshg112",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=5.6.4",
+        "illuminate/notifications": "^5.3",
+        "illuminate/support": "^5.1|^5.2|^5.3"
+    },
+    "require-dev": {
+        "mockery/mockery": "^0.9.5",
+        "phpunit/phpunit": "4.*"
+    },
+    "autoload": {
+        "psr-4": {
+            "NotificationChannels\\PusherApiNotifications\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NotificationChannels\\PusherApiNotifications\\Test\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "illuminate/notifications": "^5.3",
         "illuminate/support": "^5.1|^5.2|^5.3",
         "pusher/pusher-http-laravel": "^4.2"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -8,6 +8,7 @@ class CouldNotSendNotification extends \Exception
     {
         $encodedResponse = is_string($response) || is_bool($response)
             ? $response : json_encode($response);
+
         return new static("Message could not be sent: $encodedResponse");
     }
 }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace NotificationChannels\PusherApiNotifications\Exceptions;
+
+class CouldNotSendNotification extends \Exception
+{
+    public static function serviceRespondedWithAnError($response)
+    {
+        return new static("Descriptive error message.");
+    }
+}

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -2,13 +2,12 @@
 
 namespace NotificationChannels\PusherApiNotifications\Exceptions;
 
-use function GuzzleHttp\json_encode;
-
 class CouldNotSendNotification extends \Exception
 {
     public static function serviceRespondedWithAnError($response)
     {
-        $encodedResponse = json_encode($response);
+        $encodedResponse = is_string($response) || is_bool($response)
+            ? $response : json_encode($response);
         return new static("Message could not be sent: $encodedResponse");
     }
 }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -2,10 +2,13 @@
 
 namespace NotificationChannels\PusherApiNotifications\Exceptions;
 
+use function GuzzleHttp\json_encode;
+
 class CouldNotSendNotification extends \Exception
 {
     public static function serviceRespondedWithAnError($response)
     {
-        return new static("Descriptive error message.");
+        $encodedResponse = json_encode($response);
+        return new static("Message could not be sent: $encodedResponse");
     }
 }

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -39,7 +39,7 @@ class PusherApiChannel
             $message['alreadyEncoded'] ?? false
         );
 
-        if (!$response) {
+        if (! $response) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);
         }
     }

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -35,9 +35,9 @@ class PusherApiChannel
             $message['channel'],
             $message['event'],
             $message['data'],
-            $message['socketId'],
-            $message['debug'],
-            $message['alreadyEncoded']
+            $message['socketId'] ?? null,
+            $message['debug'] ?? false,
+            $message['alreadyEncoded'] ?? false
         );
 
         if (!$response) {

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -32,7 +32,7 @@ class PusherApiChannel
         $message = $message instanceof PusherApiMessage ? $message->toArray() : $message;
 
         $response = $this->pusher->trigger(
-            $message['channel'],
+            $message['channels'],
             $message['event'],
             $message['data'],
             $message['socketId'] ?? null,

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -25,10 +25,10 @@ class PusherApiChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        /** @var PusherApiMessage|array $message */
-        $message = $notification->toApiNotification($notifiable);
+        /** @var PusherApiMessage $pusherApiMessage */
+        $pusherApiMessage = $notification->toApiNotification($notifiable);
 
-        $message = $message instanceof PusherApiMessage ? $message->toArray() : $message;
+        $message = $pusherApiMessage->toArray();
 
         $response = $this->pusher::trigger(
             $message['channels'],

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace NotificationChannels\PusherApiNotifications;
+
+use NotificationChannels\PusherApiNotifications\Exceptions\CouldNotSendNotification;
+use NotificationChannels\PusherApiNotifications\Events\MessageWasSent;
+use NotificationChannels\PusherApiNotifications\Events\SendingMessage;
+use Illuminate\Notifications\Notification;
+
+class PusherApiChannel
+{
+    public function __construct()
+    {
+        // Initialisation code here
+    }
+
+    /**
+     * Send the given notification.
+     *
+     * @param mixed $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     *
+     * @throws \NotificationChannels\PusherApiNotifications\Exceptions\CouldNotSendNotification
+     */
+    public function send($notifiable, Notification $notification)
+    {
+        //$response = [a call to the api of your notification send]
+
+        //        if ($response->error) { // replace this by the code need to check for errors
+        //            throw CouldNotSendNotification::serviceRespondedWithAnError($response);
+        //        }
+    }
+}

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -26,12 +26,18 @@ class PusherApiChannel
      */
     public function send($notifiable, Notification $notification)
     {
+        /** @var PusherApiMessage|array $message */
         $message = $notification->toApiNotification($notifiable);
+
+        $message = $message instanceof PusherApiMessage ? $message->toArray() : $message;
 
         $response = $this->pusher->trigger(
             $message['channel'],
             $message['event'],
-            $message['message']
+            $message['data'],
+            $message['socketId'],
+            $message['debug'],
+            $message['alreadyEncoded']
         );
 
         if (!$response) {

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -4,14 +4,13 @@ namespace NotificationChannels\PusherApiNotifications;
 
 use Illuminate\Notifications\Notification;
 use NotificationChannels\PusherApiNotifications\Exceptions\CouldNotSendNotification;
-use Pusher\Laravel\PusherManager;
 
 class PusherApiChannel
 {
-    /** @var PusherManager|\Pusher\Pusher $pusher */
+    /** @var \Pusher|\Pusher\Pusher $pusher */
     protected $pusher;
 
-    public function __construct(PusherManager $pusher)
+    public function __construct(\Pusher $pusher)
     {
         $this->pusher = $pusher;
     }

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -30,7 +30,7 @@ class PusherApiChannel
 
         $message = $message instanceof PusherApiMessage ? $message->toArray() : $message;
 
-        $response = $this->pusher->trigger(
+        $response = $this->pusher::trigger(
             $message['channels'],
             $message['event'],
             $message['data'],

--- a/src/PusherApiChannel.php
+++ b/src/PusherApiChannel.php
@@ -2,16 +2,18 @@
 
 namespace NotificationChannels\PusherApiNotifications;
 
-use NotificationChannels\PusherApiNotifications\Exceptions\CouldNotSendNotification;
-use NotificationChannels\PusherApiNotifications\Events\MessageWasSent;
-use NotificationChannels\PusherApiNotifications\Events\SendingMessage;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\PusherApiNotifications\Exceptions\CouldNotSendNotification;
+use Pusher\Laravel\PusherManager;
 
 class PusherApiChannel
 {
-    public function __construct()
+    /** @var PusherManager|\Pusher\Pusher $pusher */
+    protected $pusher;
+
+    public function __construct(PusherManager $pusher)
     {
-        // Initialisation code here
+        $this->pusher = $pusher;
     }
 
     /**
@@ -24,10 +26,16 @@ class PusherApiChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        //$response = [a call to the api of your notification send]
+        $message = $notification->toApiNotification($notifiable);
 
-        //        if ($response->error) { // replace this by the code need to check for errors
-        //            throw CouldNotSendNotification::serviceRespondedWithAnError($response);
-        //        }
+        $response = $this->pusher->trigger(
+            $message['channel'],
+            $message['event'],
+            $message['message']
+        );
+
+        if (!$response) {
+            throw CouldNotSendNotification::serviceRespondedWithAnError($response);
+        }
     }
 }

--- a/src/PusherApiMessage.php
+++ b/src/PusherApiMessage.php
@@ -16,10 +16,10 @@ class PusherApiMessage
     /** @var string $socketId */
     protected $socketId = null;
 
-    /** @var boolean $debug */
+    /** @var bool $debug */
     protected $debug = false;
 
-    /** @var boolean $alreadyEncoded */
+    /** @var bool $alreadyEncoded */
     protected $alreadyEncoded = false;
 
     /**
@@ -29,8 +29,8 @@ class PusherApiMessage
      * @param string $event
      * @param mixed $data
      * @param string|null $socketId
-     * @param boolean $debug
-     * @param boolean $alreadyEncoded
+     * @param bool $debug
+     * @param bool $alreadyEncoded
      */
     public function __construct(
         $channels = null,
@@ -88,7 +88,7 @@ class PusherApiMessage
     }
 
     /**
-     * [optional]
+     * [optional].
      *
      * @param string|null $socketId
      * @return  $this
@@ -101,9 +101,9 @@ class PusherApiMessage
     }
 
     /**
-     * [optional]
+     * [optional].
      *
-     * @param boolean $debug
+     * @param bool $debug
      * @return  $this
      */
     public function debug($debug = false)
@@ -114,9 +114,9 @@ class PusherApiMessage
     }
 
     /**
-     * [optional]
+     * [optional].
      *
-     * @param boolean $alreadyEncoded
+     * @param bool $alreadyEncoded
      * @return  $this
      */
     public function alreadyEncoded($alreadyEncoded = false)

--- a/src/PusherApiMessage.php
+++ b/src/PusherApiMessage.php
@@ -6,5 +6,111 @@ use Illuminate\Support\Arr;
 
 class PusherApiMessage
 {
-    // Message structure here
+    /** @var string $channels */
+    protected $channels = null;
+
+    /** @var string $event */
+    protected $event = null;
+
+    /** @var array|string $data */
+    protected $data = null;
+
+    /** @var string $socketId */
+    protected $socketId = null;
+
+    /** @var boolean $debug */
+    protected $debug = false;
+
+    /** @var boolean $alreadyEncoded */
+    protected $alreadyEncoded = false;
+
+    /**
+     * A channel name or an array of channel names to publish the event on.
+     *
+     * @param array|string $channels
+     * @return  $this
+     */
+    public function channels($channels)
+    {
+        $this->channels = $channels;
+
+        return $this;
+    }
+
+    /**
+     * Pusher event.
+     *
+     * @param string $event
+     * @return  $this
+     */
+    public function event($event)
+    {
+        $this->event = $event;
+
+        return $this;
+    }
+
+    /**
+     * Event data.
+     *
+     * @param mixed $data
+     * @return  $this
+     */
+    public function data($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * [optional]
+     *
+     * @param string|null $socketId
+     * @return  $this
+     */
+    public function socketId($socketId = null)
+    {
+        $this->socketId = $socketId;
+
+        return $this;
+    }
+
+    /**
+     * [optional]
+     *
+     * @param boolean $debug
+     * @return  $this
+     */
+    public function debug($debug = false)
+    {
+        $this->debug = $debug;
+
+        return $this;
+    }
+
+    /**
+     * [optional]
+     *
+     * @param boolean $alreadyEncoded
+     * @return  $this
+     */
+    public function alreadyEncoded($alreadyEncoded = false)
+    {
+        $this->alreadyEncoded = $alreadyEncoded;
+
+        return $this;
+    }
+
+    public function toArray()
+    {
+        return [
+            'channels' => $this->channels,
+            'event' => $this->event,
+            'data' => $this->data,
+            'socketId' => $this->socketId,
+            'debug' => $this->debug,
+            'alreadyEncoded' => $this->alreadyEncoded,
+        ];
+    }
 }

--- a/src/PusherApiMessage.php
+++ b/src/PusherApiMessage.php
@@ -25,6 +25,32 @@ class PusherApiMessage
     protected $alreadyEncoded = false;
 
     /**
+     * Creates the instance.
+     *
+     * @param array|string $channels
+     * @param string $event
+     * @param mixed $data
+     * @param string|null $socketId
+     * @param boolean $debug
+     * @param boolean $alreadyEncoded
+     */
+    public function __construct(
+        $channels = null,
+        $event = null,
+        $data = null,
+        $socketId = null,
+        $debug = false,
+        $alreadyEncoded = false
+    ) {
+        $this->channels = $channels;
+        $this->event = $event;
+        $this->data = $data;
+        $this->socketId = $socketId;
+        $this->debug = $debug;
+        $this->alreadyEncoded = $alreadyEncoded;
+    }
+
+    /**
      * A channel name or an array of channel names to publish the event on.
      *
      * @param array|string $channels

--- a/src/PusherApiMessage.php
+++ b/src/PusherApiMessage.php
@@ -2,8 +2,6 @@
 
 namespace NotificationChannels\PusherApiNotifications;
 
-use Illuminate\Support\Arr;
-
 class PusherApiMessage
 {
     /** @var string $channels */

--- a/src/PusherApiMessage.php
+++ b/src/PusherApiMessage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace NotificationChannels\PusherApiNotifications;
+
+use Illuminate\Support\Arr;
+
+class PusherApiMessage
+{
+    // Message structure here
+}

--- a/src/PusherApiServiceProvider.php
+++ b/src/PusherApiServiceProvider.php
@@ -13,7 +13,7 @@ class PusherApiServiceProvider extends ServiceProvider
     {
         // Bootstrap code here.
 
-        /**
+        /*
          * Here's some example code we use for the pusher package.
 
         $this->app->when(Channel::class)
@@ -34,5 +34,6 @@ class PusherApiServiceProvider extends ServiceProvider
      * Register the application services.
      */
     public function register()
-    { }
+    {
+    }
 }

--- a/src/PusherApiServiceProvider.php
+++ b/src/PusherApiServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace NotificationChannels\PusherApiNotifications;
+
+use Illuminate\Support\ServiceProvider;
+
+class PusherApiServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     */
+    public function boot()
+    {
+        // Bootstrap code here.
+
+        /**
+         * Here's some example code we use for the pusher package.
+
+        $this->app->when(Channel::class)
+            ->needs(Pusher::class)
+            ->give(function () {
+                $pusherConfig = config('broadcasting.connections.pusher');
+
+                return new Pusher(
+                    $pusherConfig['key'],
+                    $pusherConfig['secret'],
+                    $pusherConfig['app_id']
+                );
+            });
+         */
+    }
+
+    /**
+     * Register the application services.
+     */
+    public function register()
+    { }
+}

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace NotificationChannels\PusherApiNotifications\Test;
+
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Mockery;
+use NotificationChannels\PusherApiNotifications\Exceptions\CouldNotSendNotification;
+use NotificationChannels\PusherApiNotifications\PusherApiChannel;
+use NotificationChannels\PusherApiNotifications\PusherApiMessage;
+use Orchestra\Testbench\TestCase;
+
+class ChannelTest extends TestCase
+{
+    /** @var \Pusher $pusher */
+    protected $pusher = null;
+
+    /** @var PusherApiChannel $channel */
+    protected $channel = null;
+
+    /** @var TestNotification $notification */
+    protected $notification = null;
+
+    /** @var TestNotifiable $notifiable */
+    protected $notifiable = null;
+
+    public function setUp(): void
+    {
+        $this->pusher = Mockery::mock(\Pusher::class);
+        $this->channel = new PusherApiChannel($this->pusher);
+        $this->notification = new TestNotification;
+        $this->notifiable = new TestNotifiable;
+
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        $this->addToAssertionCount(
+            Mockery::getContainer()->mockery_getExpectationCount()
+        );
+
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_can_send_a_notification()
+    {
+        /** @var PusherApiMessage $message */
+        $message = $this->notification->toApiNotification($this->notifiable);
+
+        $data = $message->toArray();
+
+        $this->pusher->shouldReceive('trigger')->with(
+            $data['channels'],
+            $data['event'],
+            $data['data'],
+            $data['socketId'],
+            $data['debug'],
+            $data['alreadyEncoded']
+        )->andReturn(true);
+
+        $this->channel->send($this->notifiable, $this->notification);
+    }
+
+    /** @test */
+    public function it_cannot_send_a_notification()
+    {
+        $this->expectException(CouldNotSendNotification::class);
+
+        /** @var PusherApiMessage $message */
+        $message = $this->notification->toApiNotification($this->notifiable);
+
+        $data = $message->toArray();
+
+        $this->pusher->shouldReceive('trigger')->with(
+            $data['channels'],
+            $data['event'],
+            $data['data'],
+            $data['socketId'],
+            $data['debug'],
+            $data['alreadyEncoded']
+        )->andReturn(false);
+
+        $this->channel->send($this->notifiable, $this->notification);
+    }
+}
+
+class TestNotifiable
+{
+    use Notifiable;
+}
+
+class TestNotification extends Notification
+{
+    public function toApiNotification($notifiable)
+    {
+        return new PusherApiMessage();
+    }
+}

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -2,13 +2,13 @@
 
 namespace NotificationChannels\PusherApiNotifications\Test;
 
+use Mockery;
+use Orchestra\Testbench\TestCase;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
-use Mockery;
-use NotificationChannels\PusherApiNotifications\Exceptions\CouldNotSendNotification;
 use NotificationChannels\PusherApiNotifications\PusherApiChannel;
 use NotificationChannels\PusherApiNotifications\PusherApiMessage;
-use Orchestra\Testbench\TestCase;
+use NotificationChannels\PusherApiNotifications\Exceptions\CouldNotSendNotification;
 
 class ChannelTest extends TestCase
 {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -6,7 +6,6 @@ use Orchestra\Testbench\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
 use NotificationChannels\PusherApiNotifications\PusherApiMessage;
 
-
 class MessageTest extends TestCase
 {
     use WithFaker;

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -2,9 +2,9 @@
 
 namespace NotificationChannels\PusherApiNotifications\Test;
 
+use Orchestra\Testbench\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
 use NotificationChannels\PusherApiNotifications\PusherApiMessage;
-use Orchestra\Testbench\TestCase;
 
 
 class MessageTest extends TestCase

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace NotificationChannels\PusherApiNotifications\Test;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use NotificationChannels\PusherApiNotifications\PusherApiMessage;
+use Orchestra\Testbench\TestCase;
+
+
+class MessageTest extends TestCase
+{
+    use WithFaker;
+
+    public function setUp(): void
+    {
+        $this->setUpFaker();
+
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_accepts_attributes_when_constructing_a_message()
+    {
+        $attributes = [
+            'channels' => $this->faker->uuid,
+            'event' => $this->faker->word,
+            'data' => $this->faker->sentence,
+            'socketId' => $this->faker->md5,
+            'debug' => $this->faker->boolean,
+            'alreadyEncoded' => $this->faker->boolean,
+        ];
+
+        $message = new PusherApiMessage(
+            $attributes['channels'],
+            $attributes['event'],
+            $attributes['data'],
+            $attributes['socketId'],
+            $attributes['debug'],
+            $attributes['alreadyEncoded']
+        );
+
+        $this->assertEquals($attributes, $message->toArray());
+    }
+
+    /** @test */
+    public function it_accepts_attributes_one_by_one()
+    {
+        $attributes = [
+            'channels' => $this->faker->uuid,
+            'event' => $this->faker->word,
+            'data' => $this->faker->sentence,
+            'socketId' => $this->faker->md5,
+            'debug' => $this->faker->boolean,
+            'alreadyEncoded' => $this->faker->boolean,
+        ];
+
+        $message = (new PusherApiMessage)
+            ->channels($attributes['channels'])
+            ->event($attributes['event'])
+            ->data($attributes['data'])
+            ->socketId($attributes['socketId'])
+            ->debug($attributes['debug'])
+            ->alreadyEncoded($attributes['alreadyEncoded']);
+
+        $this->assertEquals($attributes, $message->toArray());
+    }
+}


### PR DESCRIPTION
This PR adds a channel for sending [Pusher API Messages](https://pusher.com/docs/javascript_quick_start) like this:
![imagen](https://user-images.githubusercontent.com/15859884/54795945-22e8fb00-4c1c-11e9-9606-aa573103d919.png)

It's fully documented and almost fully tested.