### PR TITLE
Added support for Laravel 5.8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/.scrutinizer.yml   export-ignore
+/tests              export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor
+build
+composer.phar
+composer.lock
+.idea

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,21 @@
+filter:
+    excluded_paths: [tests/*]
+
+checks:
+    php:
+        remove_extra_empty_lines: true
+        remove_php_closing_tag: true
+        remove_trailing_whitespace: true
+        fix_use_statements:
+            remove_unused: true
+            preserve_multiple: false
+            preserve_blanklines: true
+            order_alphabetically: true
+        fix_php_opening_tag: true
+        fix_linefeed: true
+        fix_line_ending: true
+        fix_identation_4spaces: true
+        fix_doc_comments: true
+
+tools:
+    external_code_coverage: true

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,3 @@
+preset: laravel
+
+linting: true

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+
+env:
+  matrix:
+    - COMPOSER_FLAGS="--prefer-lowest"
+    - COMPOSER_FLAGS=""
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+
+script:
+  - phpunit --coverage-text --coverage-clover=coverage.clover
+
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,9 @@ php:
   - 7.0
   - 7.1
 
-env:
-  matrix:
-    - COMPOSER_FLAGS="--prefer-lowest"
-    - COMPOSER_FLAGS=""
-
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer update --no-interaction --prefer-source
 
 script:
   - phpunit --coverage-text --coverage-clover=coverage.clover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to `exponent-push-notifications` will be documented in this file
+
+## 1.0.0 - 2017-XX-XX
+
+- initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+Please read and understand the contribution guide before creating an issue or pull request.
+
+## Etiquette
+
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
+
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
+
+**Happy coding**!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) Aly Suleiman <alymosul@gmail.com>
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can install the package via composer:
 composer require alymosul/laravel-exponent-push-notifications
 ```
 
-You must install the service provider:
+If you are using Laravel 5.5 or higher this package will automatically register itself using [Package Discovery](https://laravel.com/docs/5.5/packages#package-discovery). For older versions of Laravel you must install the service provider manually:
 
 ```php
 // config/app.php
@@ -36,6 +36,39 @@ You must install the service provider:
     ...
     NotificationChannels\ExpoPushNotifications\ExpoPushNotificationsServiceProvider::class,
 ],
+```
+
+You can publish the migration with:
+```bash
+php artisan vendor:publish --provider="NotificationChannels\ExpoPushNotifications\ExpoPushNotificationsServiceProvider" --tag="migrations"
+```
+
+After publishing the migration you can create the `exponent_push_notification_interests` table by running the migrations:
+
+```bash
+php artisan migrate
+```
+
+You can optionally publish the config file with:
+```bash
+php artisan vendor:publish --provider="NotificationChannels\ExpoPushNotifications\ExpoPushNotificationsServiceProvider" --tag="config"
+```
+
+This is the contents of the published config file:
+
+```php
+return [
+    'interests' => [
+        /*
+         * Supported: "file", "database"
+         */
+        'driver' => env('EXPONENT_PUSH_NOTIFICATION_INTERESTS_STORAGE_DRIVER', 'file'),
+
+        'database' => [
+            'table_name' => 'exponent_push_notification_interests',
+        ],
+    ]
+];
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,106 @@
-# new-channels
+# Exponent push notifications channel for Laravel 5.3
 
-Discuss about new channel proposals our share your finished channels in the [proposal issue](https://github.com/laravel-notification-channels/new-channels/issues/6).
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/laravel-exponent-push-notifications.svg?style=flat-square)](https://packagist.org/packages/alymosul/laravel-exponent-push-notifications)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://travis-ci.org/Alymosul/laravel-exponent-push-notifications.svg?branch=master)](https://travis-ci.org/Alymosul/laravel-exponent-push-notifications)
+[![StyleCI](https://styleci.io/repos/96645200/shield?branch=master)](https://styleci.io/repos/96645200)
+[![SensioLabsInsight](https://img.shields.io/sensiolabs/i/:sensio_labs_id.svg?style=flat-square)](https://insight.sensiolabs.com/projects/:sensio_labs_id)
+[![Quality Score](https://img.shields.io/scrutinizer/g/alymosul/laravel-exponent-push-notifications.svg?style=flat-square)](https://scrutinizer-ci.com/g/alymosul/laravel-exponent-push-notifications)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/alymosul/laravel-exponent-push-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/alymosul/laravel-exponent-push-notifications/?branch=master)
+[![Total Downloads](https://img.shields.io/packagist/dt/alymosul/laravel-exponent-push-notifications.svg?style=flat-square)](https://packagist.org/packages/alymosul/laravel-exponent-push-notifications)
 
-Take a look at our [FAQ](http://laravel-notification-channels.com/) to see our small list of rules, to provide top-notch notification channels.
+## Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+	- [Available Message methods](#available-message-methods)
+- [Changelog](#changelog)
+- [Testing](#testing)
+- [Security](#security)
+- [Contributing](#contributing)
+- [Credits](#credits)
+- [License](#license)
+
+
+## Installation
+You can install the package via composer:
+```bash
+composer require laravel-notification-channels/exponent-push-notifications
+```
+You must install the service provider:
+
+```php
+// config/app.php
+'providers' => [
+    ...
+    NotificationChannels\ExpoPushNotifications\ExpoPushNotificationsServiceProvider::class,
+],
+```
+
+## Usage
+
+``` php
+use NotificationChannels\ExpoPushNotifications\ExpoChannel;
+use NotificationChannels\ExpoPushNotifications\ExpoMessage;
+use Illuminate\Notifications\Notification;
+
+class AccountApproved extends Notification
+{
+    public function via($notifiable)
+    {
+        return [ExpoChannel::class];
+    }
+
+    public function toExpoPush($notifiable)
+    {
+        return ExpoMessage::create()
+            ->badge(1)
+            ->enableSound()
+            ->body("Your {$notifiable->service} account was approved!");
+    }
+}
+```
+
+### Available Message methods
+
+A list of all available options
+- `body('')`: Accepts a string value for the body.
+- `enableSound()`: Enables the notification sound.
+- `disableSound()`: Mutes the notification sound.
+- `badge(1)`: Accepts an integer value for the badge.
+- `ttl(60)`: Accepts an integer value for the time to live.
+
+### Managing Recipients
+
+This package registers two endpoints that handle the subscription of recipients, the endpoints are defined in src/Http/routes.php file, used by ExpoController and all loaded through the package service provider.
+
+### Routing a message
+
+By default the exponent "interest" messages will be sent to will be defined using the {notifiable}.{id} convention, for example `App.User.1`, however you can change this behaviour by including a `routeNotificationForExpoPushNotifications()` in the notifiable class method that returns the interest name.
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+
+## Testing
+
+``` bash
+$ composer test
+```
+
+## Security
+
+If you discover any security related issues, please email alymosul@gmail.com instead of using the issue tracker.
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+## Credits
+
+- [Aly Suleiman](https://github.com/Alymosul)
+- [All Contributors](../../contributors)
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Installation
 You can install the package via composer:
 ```bash
-composer require alymosul/exponent-push-notifications
+composer require alymosul/laravel-exponent-push-notifications
 ```
 You must install the service provider:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://travis-ci.org/Alymosul/laravel-exponent-push-notifications.svg?branch=master)](https://travis-ci.org/Alymosul/laravel-exponent-push-notifications)
 [![StyleCI](https://styleci.io/repos/96645200/shield?branch=master)](https://styleci.io/repos/96645200)
-[![SensioLabsInsight](https://img.shields.io/sensiolabs/i/:sensio_labs_id.svg?style=flat-square)](https://insight.sensiolabs.com/projects/:sensio_labs_id)
+[![SensioLabsInsight](https://insight.sensiolabs.com/projects/afe0ba9a-e35c-4759-a06f-14a081cf452c/big.png)](https://insight.sensiolabs.com/projects/afe0ba9a-e35c-4759-a06f-14a081cf452c)
 [![Quality Score](https://img.shields.io/scrutinizer/g/alymosul/laravel-exponent-push-notifications.svg?style=flat-square)](https://scrutinizer-ci.com/g/alymosul/laravel-exponent-push-notifications)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/alymosul/laravel-exponent-push-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/alymosul/laravel-exponent-push-notifications/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/alymosul/laravel-exponent-push-notifications.svg?style=flat-square)](https://packagist.org/packages/alymosul/laravel-exponent-push-notifications)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ You can install the package via composer:
 ```bash
 composer require alymosul/laravel-exponent-push-notifications
 ```
+
+If you use Laravel <= 5.4, please use release v1.0:
+```bash
+composer require alymosul/laravel-exponent-push-notifications dev-master#v1.0
+```
+
 You must install the service provider:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exponent push notifications channel for Laravel 5.3
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/laravel-exponent-push-notifications.svg?style=flat-square)](https://packagist.org/packages/alymosul/laravel-exponent-push-notifications)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/alymosul/laravel-exponent-push-notifications.svg?style=flat-square)](https://packagist.org/packages/alymosul/laravel-exponent-push-notifications)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://travis-ci.org/Alymosul/laravel-exponent-push-notifications.svg?branch=master)](https://travis-ci.org/Alymosul/laravel-exponent-push-notifications)
 [![StyleCI](https://styleci.io/repos/96645200/shield?branch=master)](https://styleci.io/repos/96645200)
@@ -25,7 +25,7 @@
 ## Installation
 You can install the package via composer:
 ```bash
-composer require laravel-notification-channels/exponent-push-notifications
+composer require alymosul/exponent-push-notifications
 ```
 You must install the service provider:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://travis-ci.org/Alymosul/laravel-exponent-push-notifications.svg?branch=master)](https://travis-ci.org/Alymosul/laravel-exponent-push-notifications)
 [![StyleCI](https://styleci.io/repos/96645200/shield?branch=master)](https://styleci.io/repos/96645200)
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/afe0ba9a-e35c-4759-a06f-14a081cf452c/big.png)](https://insight.sensiolabs.com/projects/afe0ba9a-e35c-4759-a06f-14a081cf452c)
+[![SensioLabsInsight](https://img.shields.io/sensiolabs/i/afe0ba9a-e35c-4759-a06f-14a081cf452c.svg?style=flat-square)](https://insight.sensiolabs.com/projects/afe0ba9a-e35c-4759-a06f-14a081cf452c)
 [![Quality Score](https://img.shields.io/scrutinizer/g/alymosul/laravel-exponent-push-notifications.svg?style=flat-square)](https://scrutinizer-ci.com/g/alymosul/laravel-exponent-push-notifications)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/alymosul/laravel-exponent-push-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/alymosul/laravel-exponent-push-notifications/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/alymosul/laravel-exponent-push-notifications.svg?style=flat-square)](https://packagist.org/packages/alymosul/laravel-exponent-push-notifications)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Exponent push notifications channel for Laravel 5.3
+# Exponent push notifications channel for Laravel 5
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/alymosul/laravel-exponent-push-notifications.svg?style=flat-square)](https://packagist.org/packages/alymosul/laravel-exponent-push-notifications)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
@@ -26,11 +26,6 @@
 You can install the package via composer:
 ```bash
 composer require alymosul/laravel-exponent-push-notifications
-```
-
-If you use Laravel <= 5.4, please use release v1.0:
-```bash
-composer require alymosul/laravel-exponent-push-notifications dev-master#v1.0
 ```
 
 You must install the service provider:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ If you are using Laravel 5.5 or higher this package will automatically register 
     ...
     NotificationChannels\ExpoPushNotifications\ExpoPushNotificationsServiceProvider::class,
 ],
-```
 
+```
+Before publish exponent notification migration you must add in .env file:  
+```bash
+EXPONENT_PUSH_NOTIFICATION_INTERESTS_STORAGE_DRIVER=database
+```
 You can publish the migration with:
 ```bash
 php artisan vendor:publish --provider="NotificationChannels\ExpoPushNotifications\ExpoPushNotificationsServiceProvider" --tag="migrations"

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "require": {
         "php": ">=7.0",
         "alymosul/exponent-server-sdk-php": "1.0.*",
-        "illuminate/notifications": "~5.5.0",
-        "illuminate/support": "~5.5.0",
-        "illuminate/events": "~5.5.0",
-        "illuminate/queue": "~5.5.0",
-        "illuminate/http": "~5.5.0",
-        "illuminate/routing": "~5.5.0",
-        "illuminate/validation": "~5.5.0",
-        "illuminate/auth": "~5.5.0"
+        "illuminate/notifications": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
+        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
+        "illuminate/events": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
+        "illuminate/queue": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
+        "illuminate/http": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
+        "illuminate/routing": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
+        "illuminate/validation": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
+        "illuminate/auth": "5.3.* || 5.4.* || 5.5.* || 5.6.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/composer.json
+++ b/composer.json
@@ -13,18 +13,18 @@
     "require": {
         "php": ">=7.0",
         "alymosul/exponent-server-sdk-php": "1.0.*",
-        "illuminate/notifications": "5.3.* || 5.4.*",
-        "illuminate/support": "5.3.* || 5.4.*",
-        "illuminate/events": "5.3.* || 5.4.*",
-        "illuminate/queue": "5.3.* || 5.4.*",
-        "illuminate/http": "5.3.* || 5.4.*",
-        "illuminate/routing": "5.3.* || 5.4.*",
-        "illuminate/validation": "5.3.* || 5.4.*",
-        "illuminate/auth": "5.3.* || 5.4.*"
+        "illuminate/notifications": "~5.5.0",
+        "illuminate/support": "~5.5.0",
+        "illuminate/events": "~5.5.0",
+        "illuminate/queue": "~5.5.0",
+        "illuminate/http": "~5.5.0",
+        "illuminate/routing": "~5.5.0",
+        "illuminate/validation": "~5.5.0",
+        "illuminate/auth": "~5.5.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,19 +12,21 @@
     ],
     "require": {
         "php": ">=7.0",
-        "alymosul/exponent-server-sdk-php": "1.0.*",
-        "illuminate/notifications": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/events": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/queue": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/http": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/routing": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/validation": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/auth": "5.3.* || 5.4.* || 5.5.* || 5.6.*"
+        "alymosul/exponent-server-sdk-php": "1.1.*",
+        "illuminate/config": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/notifications": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/events": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/queue": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/http": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/routing": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/validation": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
+        "illuminate/auth": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "~5.4||~5.7||~6.0||^7.0",
+        "orchestra/testbench": "~3.3||~3.4||~3.5||~3.6||~3.7"
     },
     "autoload": {
         "psr-4": {
@@ -41,5 +43,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "NotificationChannels\\ExpoPushNotifications\\ExpoPushNotificationsServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "alymosul/exponent-push-notifications",
+    "name": "alymosul/laravel-exponent-push-notifications",
     "description": "Exponent push notifications driver for laravel",
-    "homepage": "https://github.com/alymosul/exponent-push-notifications",
+    "homepage": "https://github.com/alymosul/laravel-exponent-push-notifications",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,45 @@
+{
+    "name": "alymosul/exponent-push-notifications",
+    "description": "Exponent push notifications driver for laravel",
+    "homepage": "https://github.com/alymosul/exponent-push-notifications",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Aly Suleiman",
+            "email": "alymosul@gmail.com",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=7.0",
+        "alymosul/exponent-server-sdk-php": "1.0.*",
+        "illuminate/notifications": "5.3 || 5.4.*",
+        "illuminate/support": "5.3 || 5.4.*",
+        "illuminate/events": "5.3 || 5.4.*",
+        "illuminate/queue": "5.3 || 5.4.*",
+        "illuminate/http": "5.3 || 5.4.*",
+        "illuminate/routing": "5.3 || 5.4.*",
+        "illuminate/validation": "5.3 || 5.4.*",
+        "illuminate/auth": "5.3 || 5.4"
+    },
+    "require-dev": {
+        "mockery/mockery": "^0.9.5",
+        "phpunit/phpunit": "~5.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "NotificationChannels\\ExpoPushNotifications\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NotificationChannels\\ExpoPushNotifications\\Test\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "require": {
         "php": ">=7.0",
         "alymosul/exponent-server-sdk-php": "1.0.*",
-        "illuminate/notifications": "5.3 || 5.4.*",
-        "illuminate/support": "5.3 || 5.4.*",
-        "illuminate/events": "5.3 || 5.4.*",
-        "illuminate/queue": "5.3 || 5.4.*",
-        "illuminate/http": "5.3 || 5.4.*",
-        "illuminate/routing": "5.3 || 5.4.*",
-        "illuminate/validation": "5.3 || 5.4.*",
-        "illuminate/auth": "5.3 || 5.4"
+        "illuminate/notifications": "5.3.* || 5.4.*",
+        "illuminate/support": "5.3.* || 5.4.*",
+        "illuminate/events": "5.3.* || 5.4.*",
+        "illuminate/queue": "5.3.* || 5.4.*",
+        "illuminate/http": "5.3.* || 5.4.*",
+        "illuminate/routing": "5.3.* || 5.4.*",
+        "illuminate/validation": "5.3.* || 5.4.*",
+        "illuminate/auth": "5.3.* || 5.4.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/config/exponent-push-notifications.php
+++ b/config/exponent-push-notifications.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Here you may define the configuration for the expo-notifications-driver.
+ * The expo-notifications-driver can guide the sdk to use `database` or `file` repositories.
+ * The database repository uses the same configuration for the database in your Laravel app.
+ */
+
+return [
+    'interests' => [
+        'driver' => env('EXPONENT_PUSH_NOTIFICATION_INTERESTS_STORAGE_DRIVER', 'file'),
+
+        'database' => [
+            'table_name' => 'exponent_push_notification_interests',
+        ],
+    ],
+];

--- a/migrations/create_exponent_push_notification_interests_table.php.stub
+++ b/migrations/create_exponent_push_notification_interests_table.php.stub
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateExponentPushNotificationInterestsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create(config('exponent-push-notifications.interests.database.table_name'), function (Blueprint $table) {
+            $table->string('key')->index();
+            $table->string('value');
+
+            $table->unique(['key','value']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::drop(config('exponent-push-notifications.interests.database.table_name'));
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="ExpoPushNotifications Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/Exceptions/CouldNotCreateMessage.php
+++ b/src/Exceptions/CouldNotCreateMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Exceptions;
+
+class CouldNotCreateMessage extends \Exception
+{
+}

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Exceptions;
+
+class CouldNotSendNotification extends \Exception
+{
+}

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -3,8 +3,8 @@
 namespace NotificationChannels\ExpoPushNotifications;
 
 use ExponentPhpSDK\Expo;
-use Illuminate\Events\Dispatcher;
 use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Events\Dispatcher;
 use ExponentPhpSDK\Exceptions\ExpoException;
 use Illuminate\Notifications\Events\NotificationFailed;
 use NotificationChannels\ExpoPushNotifications\Exceptions\CouldNotSendNotification;

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications;
+
+use ExponentPhpSDK\Exceptions\ExpoException;
+use ExponentPhpSDK\Expo;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationFailed;
+use NotificationChannels\ExpoPushNotifications\Exceptions\CouldNotSendNotification;
+use Illuminate\Notifications\Notification;
+
+class ExpoChannel
+{
+    /**
+     * @var Dispatcher
+     */
+    private $events;
+
+    /**
+     * @var Expo
+     */
+    public $expo;
+
+    /**
+     * ExpoChannel constructor.
+     *
+     * @param Expo $expo
+     * @param Dispatcher $events
+     */
+    public function __construct(Expo $expo, Dispatcher $events)
+    {
+        $this->events = $events;
+        $this->expo = $expo;
+    }
+
+    /**
+     * Send the given notification
+     *
+     * @param mixed $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     *
+     * @throws CouldNotSendNotification
+     *
+     * @return void
+     */
+    public function send($notifiable, Notification $notification)
+    {
+        $interest = $notifiable->routeNotificationFor('ExpoPushNotifications')
+            ?: $this->interestName($notifiable);
+
+        try {
+            $response = $this->expo->notify(
+                $interest,
+                $notification->toExpoPush($notifiable)->toArray(),
+                true
+            );
+        } catch (ExpoException $e) {
+            $this->events->fire(
+                new NotificationFailed($notifiable, $notification, 'expo-push-notifications', $e->getMessage())
+            );
+        }
+    }
+
+    /**
+     * Get the interest name for the notifiable.
+     *
+     * @param $notifiable
+     *
+     * @return string
+     */
+    public function interestName($notifiable)
+    {
+        $class = str_replace('\\', '.', get_class($notifiable));
+
+        return $class.'.'.$notifiable->getKey();
+    }
+}

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -49,7 +49,7 @@ class ExpoChannel
             ?: $this->interestName($notifiable);
 
         try {
-            $response = $this->expo->notify(
+            $this->expo->notify(
                 $interest,
                 $notification->toExpoPush($notifiable)->toArray(),
                 true

--- a/src/ExpoChannel.php
+++ b/src/ExpoChannel.php
@@ -2,12 +2,12 @@
 
 namespace NotificationChannels\ExpoPushNotifications;
 
-use ExponentPhpSDK\Exceptions\ExpoException;
 use ExponentPhpSDK\Expo;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Notifications\Notification;
+use ExponentPhpSDK\Exceptions\ExpoException;
 use Illuminate\Notifications\Events\NotificationFailed;
 use NotificationChannels\ExpoPushNotifications\Exceptions\CouldNotSendNotification;
-use Illuminate\Notifications\Notification;
 
 class ExpoChannel
 {
@@ -34,7 +34,7 @@ class ExpoChannel
     }
 
     /**
-     * Send the given notification
+     * Send the given notification.
      *
      * @param mixed $notifiable
      * @param \Illuminate\Notifications\Notification $notification

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -47,7 +47,7 @@ class ExpoMessage
      *
      * @var string
      */
-    protected $jsonData = '';
+    protected $jsonData = '{}';
 
     /**
      * Create a message with given body.
@@ -147,6 +147,7 @@ class ExpoMessage
     public function setChannelId(string $channelId)
     {
         $this->channelId = $channelId;
+        
         return $this;
     }
 

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -141,10 +141,13 @@ class ExpoMessage
      * Set the channelId of the notification for Android devices.
      *
      * @param string $channelId
+     *
+     * @return $this
      */
     public function setChannelId(string $channelId)
     {
         $this->channelId = $channelId;
+        return $this;
     }
 
     /**

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -2,6 +2,8 @@
 
 namespace NotificationChannels\ExpoPushNotifications;
 
+use NotificationChannels\ExpoPushNotifications\Exceptions\CouldNotCreateMessage;
+
 class ExpoMessage
 {
     /**
@@ -34,6 +36,15 @@ class ExpoMessage
     protected $ttl = 0;
 
     /**
+     * The json data attached to the message.
+     *
+     * @var string
+     */
+    protected $jsonData = '';
+
+    /**
+     * Create a message with given body.
+     *
      * @param string $body
      *
      * @return static
@@ -120,6 +131,32 @@ class ExpoMessage
     }
 
     /**
+     * Set the json Data attached to the message.
+     *
+     * @param array|string $data
+     *
+     * @return $this
+     *
+     * @throws CouldNotCreateMessage
+     */
+    public function setJsonData($data)
+    {
+        if (is_array($data)) {
+            $data = json_encode($data);
+        } elseif (is_string($data)) {
+            @json_decode($data);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new CouldNotCreateMessage('Invalid json format passed to the setJsonData().');
+            }
+        }
+
+        $this->jsonData = $data;
+
+        return $this;
+    }
+
+    /**
      * Get an array representation of the message.
      *
      * @return array
@@ -127,10 +164,11 @@ class ExpoMessage
     public function toArray()
     {
         return [
-            'body'  =>  $this->body,
-            'sound' =>  $this->sound,
-            'badge' =>  $this->badge,
-            'ttl'   =>  $this->ttl,
+            'body'      =>  $this->body,
+            'sound'     =>  $this->sound,
+            'badge'     =>  $this->badge,
+            'ttl'       =>  $this->ttl,
+            'data'  => $this->jsonData,
         ];
     }
 }

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -40,7 +40,7 @@ class ExpoMessage
      *
      * @var string
      */
-    protected $channelId = "Default";
+    protected $channelId = 'Default';
 
     /**
      * The json data attached to the message.

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications;
+
+class ExpoMessage
+{
+    /**
+     * The message body.
+     *
+     * @var string
+     */
+    protected $body;
+
+    /**
+     * The sound to play when the recipient receives this notification.
+     *
+     * @var string|null
+     */
+    protected $sound = 'default';
+
+    /**
+     * The number to display next to the push notification (iOS).
+     * Specify zero to clear the badge.
+     *
+     * @var int
+     */
+    protected $badge = 0;
+
+    /**
+     * The number of seconds for which the message may be kept around for redelivery if it has not been delivered yet.
+     *
+     * @var int
+     */
+    protected $ttl = 0;
+
+    /**
+     * @param string $body
+     *
+     * @return static
+     */
+    public static function create($body = '')
+    {
+        return new static($body);
+    }
+
+    /**
+     * ExpoMessage constructor.
+     *
+     * @param string $body
+     */
+    public function __construct(string $body = '')
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * Set the message body.
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function body(string $value)
+    {
+        $this->body = $value;
+
+        return $this;
+    }
+
+    /**
+     * Enable the message sound.
+     *
+     * @return $this
+     */
+    public function enableSound()
+    {
+        $this->sound = 'default';
+
+        return $this;
+    }
+
+    /**
+     * Disable the message sound.
+     *
+     * @return $this
+     */
+    public function disableSound()
+    {
+        $this->sound = null;
+
+        return $this;
+    }
+
+    /**
+     * Set the message badge (iOS).
+     *
+     * @param int $value
+     *
+     * @return $this
+     */
+    public function badge(int $value)
+    {
+        $this->badge = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the time to live of the notification
+     *
+     * @param int $ttl
+     *
+     * @return $this
+     */
+    public function setTtl(int $ttl)
+    {
+        $this->ttl = $ttl;
+
+        return $this;
+    }
+
+    /**
+     * Get an array representation of the message
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'body'  =>  $this->body,
+            'sound' =>  $this->sound,
+            'badge' =>  $this->badge,
+            'ttl'   =>  $this->ttl,
+        ];
+    }
+}

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -106,7 +106,7 @@ class ExpoMessage
     }
 
     /**
-     * Set the time to live of the notification
+     * Set the time to live of the notification.
      *
      * @param int $ttl
      *
@@ -120,7 +120,7 @@ class ExpoMessage
     }
 
     /**
-     * Get an array representation of the message
+     * Get an array representation of the message.
      *
      * @return array
      */

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -147,7 +147,7 @@ class ExpoMessage
     public function setChannelId(string $channelId)
     {
         $this->channelId = $channelId;
-        
+
         return $this;
     }
 

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -7,6 +7,13 @@ use NotificationChannels\ExpoPushNotifications\Exceptions\CouldNotCreateMessage;
 class ExpoMessage
 {
     /**
+     * The message title.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
      * The message body.
      *
      * @var string
@@ -69,6 +76,20 @@ class ExpoMessage
     public function __construct(string $body = '')
     {
         $this->body = $body;
+    }
+
+    /**
+     * Set the message title.
+     *
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function title(string $value)
+    {
+        $this->title = $value;
+
+        return $this;
     }
 
     /**
@@ -185,6 +206,7 @@ class ExpoMessage
     public function toArray()
     {
         return [
+            'title'     =>  $this->title,
             'body'      =>  $this->body,
             'sound'     =>  $this->sound,
             'badge'     =>  $this->badge,

--- a/src/ExpoMessage.php
+++ b/src/ExpoMessage.php
@@ -36,6 +36,13 @@ class ExpoMessage
     protected $ttl = 0;
 
     /**
+     * ID of the Notification Channel through which to display this notification on Android devices.
+     *
+     * @var string
+     */
+    protected $channelId = "Default";
+
+    /**
      * The json data attached to the message.
      *
      * @var string
@@ -131,6 +138,16 @@ class ExpoMessage
     }
 
     /**
+     * Set the channelId of the notification for Android devices.
+     *
+     * @param string $channelId
+     */
+    public function setChannelId(string $channelId)
+    {
+        $this->channelId = $channelId;
+    }
+
+    /**
      * Set the json Data attached to the message.
      *
      * @param array|string $data
@@ -168,7 +185,8 @@ class ExpoMessage
             'sound'     =>  $this->sound,
             'badge'     =>  $this->badge,
             'ttl'       =>  $this->ttl,
-            'data'  => $this->jsonData,
+            'channelId' =>  $this->channelId,
+            'data'      => $this->jsonData,
         ];
     }
 }

--- a/src/ExpoPushNotificationsServiceProvider.php
+++ b/src/ExpoPushNotificationsServiceProvider.php
@@ -7,29 +7,88 @@ use ExponentPhpSDK\ExpoRegistrar;
 use ExponentPhpSDK\ExpoRepository;
 use Illuminate\Support\ServiceProvider;
 use ExponentPhpSDK\Repositories\ExpoFileDriver;
+use NotificationChannels\ExpoPushNotifications\Repositories\ExpoDatabaseDriver;
 
 class ExpoPushNotificationsServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap the application services.
+     *
+     * @return void
      */
     public function boot()
     {
+        $this->setupConfig();
+
+        $repository = $this->getInterestsDriver();
+
+        $this->shouldPublishMigrations($repository);
+
         $this->app->when(ExpoChannel::class)
             ->needs(Expo::class)
-            ->give(function () {
-                return new Expo(new ExpoRegistrar(new ExpoFileDriver()));
+            ->give(function () use ($repository) {
+                return new Expo(new ExpoRegistrar($repository));
             });
 
-        //Load routes
         $this->loadRoutesFrom(__DIR__.'/Http/routes.php');
     }
 
     /**
      * Register the application services.
+     *
+     * @return void
      */
     public function register()
     {
-        $this->app->bind(ExpoRepository::class, ExpoFileDriver::class);
+        $this->app->bind(ExpoRepository::class, get_class($this->getInterestsDriver()));
+    }
+
+    /**
+     * Gets the Expo repository driver based on config.
+     *
+     * @return ExpoRepository
+     */
+    public function getInterestsDriver()
+    {
+        $driver = config('exponent-push-notifications.interests.driver');
+
+        switch ($driver) {
+            case 'database':
+                return new ExpoDatabaseDriver();
+                break;
+            default:
+                return new ExpoFileDriver();
+        }
+    }
+
+    /**
+     * Publishes the configuration files for the package.
+     *
+     * @return void
+     */
+    protected function setupConfig()
+    {
+        $this->publishes([
+            __DIR__ . '/../config/exponent-push-notifications.php' => config_path('exponent-push-notifications.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(__DIR__.'/../config/exponent-push-notifications.php', 'exponent-push-notifications');
+    }
+
+    /**
+     * Publishes the migration files needed in the package.
+     *
+     * @param ExpoRepository $repository
+     *
+     * @return void
+     */
+    private function shouldPublishMigrations(ExpoRepository $repository)
+    {
+        if ($repository instanceof ExpoDatabaseDriver && !class_exists('CreateExponentPushNotificationInterestsTable')) {
+            $timestamp = date('Y_m_d_His', time());
+            $this->publishes([
+                __DIR__ . '/../migrations/create_exponent_push_notification_interests_table.php.stub' => database_path("/migrations/{$timestamp}_create_exponent_push_notification_interests_table.php"),
+            ], 'migrations');
+        }
     }
 }

--- a/src/ExpoPushNotificationsServiceProvider.php
+++ b/src/ExpoPushNotificationsServiceProvider.php
@@ -69,7 +69,7 @@ class ExpoPushNotificationsServiceProvider extends ServiceProvider
     protected function setupConfig()
     {
         $this->publishes([
-            __DIR__ . '/../config/exponent-push-notifications.php' => config_path('exponent-push-notifications.php'),
+            __DIR__.'/../config/exponent-push-notifications.php' => config_path('exponent-push-notifications.php'),
         ], 'config');
 
         $this->mergeConfigFrom(__DIR__.'/../config/exponent-push-notifications.php', 'exponent-push-notifications');
@@ -84,10 +84,10 @@ class ExpoPushNotificationsServiceProvider extends ServiceProvider
      */
     private function shouldPublishMigrations(ExpoRepository $repository)
     {
-        if ($repository instanceof ExpoDatabaseDriver && !class_exists('CreateExponentPushNotificationInterestsTable')) {
+        if ($repository instanceof ExpoDatabaseDriver && ! class_exists('CreateExponentPushNotificationInterestsTable')) {
             $timestamp = date('Y_m_d_His', time());
             $this->publishes([
-                __DIR__ . '/../migrations/create_exponent_push_notification_interests_table.php.stub' => database_path("/migrations/{$timestamp}_create_exponent_push_notification_interests_table.php"),
+                __DIR__.'/../migrations/create_exponent_push_notification_interests_table.php.stub' => database_path("/migrations/{$timestamp}_create_exponent_push_notification_interests_table.php"),
             ], 'migrations');
         }
     }

--- a/src/ExpoPushNotificationsServiceProvider.php
+++ b/src/ExpoPushNotificationsServiceProvider.php
@@ -5,8 +5,8 @@ namespace NotificationChannels\ExpoPushNotifications;
 use ExponentPhpSDK\Expo;
 use ExponentPhpSDK\ExpoRegistrar;
 use ExponentPhpSDK\ExpoRepository;
-use ExponentPhpSDK\Repositories\ExpoFileDriver;
 use Illuminate\Support\ServiceProvider;
+use ExponentPhpSDK\Repositories\ExpoFileDriver;
 
 class ExpoPushNotificationsServiceProvider extends ServiceProvider
 {
@@ -22,7 +22,7 @@ class ExpoPushNotificationsServiceProvider extends ServiceProvider
             });
 
         //Load routes
-        $this->loadRoutesFrom(__DIR__ . '/Http/routes.php');
+        $this->loadRoutesFrom(__DIR__.'/Http/routes.php');
     }
 
     /**

--- a/src/ExpoPushNotificationsServiceProvider.php
+++ b/src/ExpoPushNotificationsServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications;
+
+use ExponentPhpSDK\Expo;
+use ExponentPhpSDK\ExpoRegistrar;
+use ExponentPhpSDK\ExpoRepository;
+use ExponentPhpSDK\Repositories\ExpoFileDriver;
+use Illuminate\Support\ServiceProvider;
+
+class ExpoPushNotificationsServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     */
+    public function boot()
+    {
+        $this->app->when(ExpoChannel::class)
+            ->needs(Expo::class)
+            ->give(function () {
+                return new Expo(new ExpoRegistrar(new ExpoFileDriver()));
+            });
+
+        //Load routes
+        $this->loadRoutesFrom(__DIR__ . '/Http/routes.php');
+    }
+
+    /**
+     * Register the application services.
+     */
+    public function register()
+    {
+        $this->app->bind(ExpoRepository::class, ExpoFileDriver::class);
+    }
+}

--- a/src/Http/ExpoController.php
+++ b/src/Http/ExpoController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Http;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use NotificationChannels\ExpoPushNotifications\ExpoChannel;
+
+class ExpoController extends Controller
+{
+    /**
+     * @var ExpoChannel
+     */
+    private $expoChannel;
+
+    /**
+     * ExpoController constructor.
+     *
+     * @param ExpoChannel $expoChannel
+     */
+    public function __construct(ExpoChannel $expoChannel)
+    {
+        $this->expoChannel = $expoChannel;
+    }
+
+    /**
+     * Handles subscription endpoint for an expo token
+     *
+     * @param Request $request
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function subscribe(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'expo_token'    =>  'required|string'
+        ]);
+
+        if ($validator->fails()) {
+            return JsonResponse::create([
+                'status' => 'failed',
+                'error' => [
+                    'message' => 'Expo Token is required'
+                ]
+            ], 422);
+        }
+
+        $token = $request->get('expo_token');
+
+        $interest = $this->expoChannel->interestName(Auth::user());
+
+        try {
+            $this->expoChannel->expo->subscribe($interest, $token);
+        } catch (\Exception $e) {
+            return JsonResponse::create([
+                'status'    => 'failed',
+                'error'     =>  [
+                    'message' => $e->getMessage()
+                ]
+            ], 500);
+        }
+
+        return JsonResponse::create([
+            'status'    =>  'succeeded',
+            'expo_token' => $token
+        ], 200);
+    }
+
+    /**
+     * Handles removing subscription endpoint for the authenticated interest
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function unsubscribe()
+    {
+        $interest = $this->expoChannel->interestName(Auth::user());
+
+        try {
+            $deleted = $this->expoChannel->expo->unsubscribe($interest);
+        } catch (\Exception $e) {
+            return JsonResponse::create([
+                'status'    => 'failed',
+                'error'     =>  [
+                    'message' => $e->getMessage()
+                ]
+            ], 500);
+        }
+
+        return JsonResponse::create(['deleted' => $deleted]);
+    }
+}

--- a/src/Http/ExpoController.php
+++ b/src/Http/ExpoController.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\ExpoPushNotifications\Http;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
@@ -27,7 +27,7 @@ class ExpoController extends Controller
     }
 
     /**
-     * Handles subscription endpoint for an expo token
+     * Handles subscription endpoint for an expo token.
      *
      * @param Request $request
      *
@@ -36,15 +36,15 @@ class ExpoController extends Controller
     public function subscribe(Request $request)
     {
         $validator = Validator::make($request->all(), [
-            'expo_token'    =>  'required|string'
+            'expo_token'    =>  'required|string',
         ]);
 
         if ($validator->fails()) {
             return JsonResponse::create([
                 'status' => 'failed',
                 'error' => [
-                    'message' => 'Expo Token is required'
-                ]
+                    'message' => 'Expo Token is required',
+                ],
             ], 422);
         }
 
@@ -58,19 +58,19 @@ class ExpoController extends Controller
             return JsonResponse::create([
                 'status'    => 'failed',
                 'error'     =>  [
-                    'message' => $e->getMessage()
-                ]
+                    'message' => $e->getMessage(),
+                ],
             ], 500);
         }
 
         return JsonResponse::create([
             'status'    =>  'succeeded',
-            'expo_token' => $token
+            'expo_token' => $token,
         ], 200);
     }
 
     /**
-     * Handles removing subscription endpoint for the authenticated interest
+     * Handles removing subscription endpoint for the authenticated interest.
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -84,8 +84,8 @@ class ExpoController extends Controller
             return JsonResponse::create([
                 'status'    => 'failed',
                 'error'     =>  [
-                    'message' => $e->getMessage()
-                ]
+                    'message' => $e->getMessage(),
+                ],
             ], 500);
         }
 

--- a/src/Http/ExpoController.php
+++ b/src/Http/ExpoController.php
@@ -72,14 +72,31 @@ class ExpoController extends Controller
     /**
      * Handles removing subscription endpoint for the authenticated interest.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @param Request $request
+     *
+     * @return JsonResponse
      */
-    public function unsubscribe()
+    public function unsubscribe(Request $request)
     {
         $interest = $this->expoChannel->interestName(Auth::user());
 
+        $validator = Validator::make($request->all(), [
+            'expo_token'    =>  'sometimes|string',
+        ]);
+
+        if ($validator->fails()) {
+            return JsonResponse::create([
+                'status' => 'failed',
+                'error' => [
+                    'message' => 'Expo Token is invalid',
+                ],
+            ], 422);
+        }
+
+        $token = $request->get('expo_token') ?: null;
+
         try {
-            $deleted = $this->expoChannel->expo->unsubscribe($interest);
+            $deleted = $this->expoChannel->expo->unsubscribe($interest, $token);
         } catch (\Exception $e) {
             return JsonResponse::create([
                 'status'    => 'failed',

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,6 +1,6 @@
 <?php
 
-Route::group(['prefix' => 'api/exponent/devices', 'middleware' => 'auth:api, bindings'], function () {
+Route::group(['prefix' => 'api/exponent/devices', 'middleware' => ['auth:api', 'bindings']], function () {
     Route::post('subscribe', [
         'as'    =>  'register-interest',
         'uses'  =>  'NotificationChannels\ExpoPushNotifications\Http\ExpoController@subscribe',

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,0 +1,13 @@
+<?php
+
+Route::group(['prefix' => 'api/exponent/devices', 'middleware' => 'auth:api, bindings'], function () {
+    Route::post('subscribe', [
+        'as'    =>  'register-interest',
+        'uses'  =>  'NotificationChannels\ExpoPushNotifications\Http\ExpoController@subscribe'
+    ]);
+
+    Route::post('unsubscribe', [
+        'as'    =>  'remove-interest',
+        'uses'  =>  'NotificationChannels\ExpoPushNotifications\Http\ExpoController@unsubscribe'
+    ]);
+});

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -3,11 +3,11 @@
 Route::group(['prefix' => 'api/exponent/devices', 'middleware' => 'auth:api, bindings'], function () {
     Route::post('subscribe', [
         'as'    =>  'register-interest',
-        'uses'  =>  'NotificationChannels\ExpoPushNotifications\Http\ExpoController@subscribe'
+        'uses'  =>  'NotificationChannels\ExpoPushNotifications\Http\ExpoController@subscribe',
     ]);
 
     Route::post('unsubscribe', [
         'as'    =>  'remove-interest',
-        'uses'  =>  'NotificationChannels\ExpoPushNotifications\Http\ExpoController@unsubscribe'
+        'uses'  =>  'NotificationChannels\ExpoPushNotifications\Http\ExpoController@unsubscribe',
     ]);
 });

--- a/src/Models/Interest.php
+++ b/src/Models/Interest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Interest extends Model
+{
+    /**
+     * The associated table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * Interest constructor.
+     *
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->table = config('exponent-push-notifications.interests.database.table_name');
+
+        parent::__construct($attributes);
+    }
+}

--- a/src/Repositories/ExpoDatabaseDriver.php
+++ b/src/Repositories/ExpoDatabaseDriver.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Repositories;
+
+use ExponentPhpSDK\ExpoRepository;
+use NotificationChannels\ExpoPushNotifications\Models\Interest;
+
+class ExpoDatabaseDriver implements ExpoRepository
+{
+    /**
+     * Stores an Expo token with a given identifier.
+     *
+     * @param $key
+     * @param $value
+     *
+     * @return bool
+     */
+    public function store($key, $value): bool
+    {
+        $interest = Interest::firstOrCreate([
+            'key' => $key,
+            'value' => $value,
+        ]);
+
+        return $interest instanceof Interest;
+    }
+
+    /**
+     * Retrieves an Expo token with a given identifier.
+     *
+     * @param string $key
+     *
+     * @return array
+     */
+    public function retrieve(string $key)
+    {
+        return Interest::where('key', $key)->pluck('value')->toArray();
+    }
+
+    /**
+     * Removes an Expo token with a given identifier.
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @return bool
+     */
+    public function forget(string $key, string $value = null): bool
+    {
+        $query = Interest::where('key', $key);
+
+        if ($value) {
+            $query->where('value', $value);
+        }
+
+        return $query->delete() > 0;
+    }
+}

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -4,7 +4,6 @@ namespace NotificationChannels\ExpoPushNotifications\Test;
 
 use Mockery;
 use ExponentPhpSDK\Expo;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
@@ -42,6 +41,8 @@ class ChannelTest extends TestCase
 
     public function setUp()
     {
+        parent::setUp();
+
         $this->expo = Mockery::mock(Expo::class);
 
         $this->events = Mockery::mock(Dispatcher::class);
@@ -55,9 +56,9 @@ class ChannelTest extends TestCase
 
     public function tearDown()
     {
-        Mockery::close();
-
         parent::tearDown();
+
+        Mockery::close();
     }
 
     /** @test */

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Test;
+
+use ExponentPhpSDK\Exceptions\ExpoException;
+use ExponentPhpSDK\Expo;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationFailed;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Mockery;
+use NotificationChannels\ExpoPushNotifications\ExpoChannel;
+use NotificationChannels\ExpoPushNotifications\ExpoMessage;
+use PHPUnit\Framework\TestCase;
+
+class ChannelTest extends TestCase
+{
+    /**
+     * @var Expo
+     */
+    protected $expo;
+
+    /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
+     * @var ExpoChannel
+     */
+    protected $channel;
+
+    /**
+     * @var TestNotification
+     */
+    protected $notification;
+
+    /**
+     * @var TestNotifiable
+     */
+    protected $notifiable;
+
+    public function setUp()
+    {
+        $this->expo = Mockery::mock(Expo::class);
+
+        $this->events = Mockery::mock(Dispatcher::class);
+
+        $this->channel = new ExpoChannel($this->expo, $this->events);
+
+        $this->notification = new TestNotification;
+
+        $this->notifiable = new TestNotifiable;
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function itCanSendANotification()
+    {
+        $message = $this->notification->toExpoPush($this->notifiable);
+
+        $data = $message->toArray();
+
+        $this->expo->shouldReceive('notify')->with('interest_name', $data, true)->andReturn([['status' => 'ok']]);
+
+        $this->channel->send($this->notifiable, $this->notification);
+    }
+
+    /** @test */
+    public function itFiresFailureEventOnFailure()
+    {
+        $message = $this->notification->toExpoPush($this->notifiable);
+
+        $data = $message->toArray();
+
+        $this->expo->shouldReceive('notify')->with('interest_name', $data, true)->andThrow(ExpoException::class, '');
+
+        $this->events->shouldReceive('fire')->with(Mockery::type(NotificationFailed::class));
+
+        $this->channel->send($this->notifiable, $this->notification);
+    }
+}
+
+class TestNotifiable
+{
+    use Notifiable;
+
+    public function routeNotificationForExpoPushNotifications()
+    {
+        return 'interest_name';
+    }
+
+    public function getKey()
+    {
+        return 1;
+    }
+}
+
+class TestNotification extends Notification
+{
+    public function toExpoPush($notifiable)
+    {
+        return new ExpoMessage();
+    }
+}

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -2,16 +2,16 @@
 
 namespace NotificationChannels\ExpoPushNotifications\Test;
 
-use ExponentPhpSDK\Exceptions\ExpoException;
+use Mockery;
 use ExponentPhpSDK\Expo;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
-use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
-use Mockery;
+use ExponentPhpSDK\Exceptions\ExpoException;
+use Illuminate\Notifications\Events\NotificationFailed;
 use NotificationChannels\ExpoPushNotifications\ExpoChannel;
 use NotificationChannels\ExpoPushNotifications\ExpoMessage;
-use PHPUnit\Framework\TestCase;
 
 class ChannelTest extends TestCase
 {

--- a/tests/ExpoControllerTest.php
+++ b/tests/ExpoControllerTest.php
@@ -3,17 +3,17 @@
 namespace NotificationChannels\ExpoPushNotifications\Test;
 
 use ExponentPhpSDK\Expo;
-use ExponentPhpSDK\ExpoRepository;
-use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Validator;
 use ExponentPhpSDK\ExpoRegistrar;
 use Illuminate\Events\Dispatcher;
+use ExponentPhpSDK\ExpoRepository;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Contracts\Validation\Factory;
 use ExponentPhpSDK\Repositories\ExpoFileDriver;
 use NotificationChannels\ExpoPushNotifications\ExpoChannel;
-use NotificationChannels\ExpoPushNotifications\Http\ExpoController;
 use NotificationChannels\ExpoPushNotifications\Models\Interest;
+use NotificationChannels\ExpoPushNotifications\Http\ExpoController;
 use NotificationChannels\ExpoPushNotifications\Repositories\ExpoDatabaseDriver;
 
 class ExpoControllerTest extends TestCase
@@ -34,6 +34,7 @@ class ExpoControllerTest extends TestCase
     {
         $expoChannel = new ExpoChannel(new Expo(new ExpoRegistrar($expoRepository)), new Dispatcher);
         $expoController = new ExpoController($expoChannel);
+
         return [$expoController, $expoChannel];
     }
 
@@ -55,7 +56,7 @@ class ExpoControllerTest extends TestCase
     }
 
     /**
-     * Data provider to help test the expo controller with the different repositories
+     * Data provider to help test the expo controller with the different repositories.
      *
      * @return array
      */
@@ -63,7 +64,7 @@ class ExpoControllerTest extends TestCase
     {
         return [
             [new ExpoDatabaseDriver],
-            [new ExpoFileDriver]
+            [new ExpoFileDriver],
         ];
     }
 
@@ -96,7 +97,7 @@ class ExpoControllerTest extends TestCase
         if ($expoRepository instanceof ExpoDatabaseDriver) {
             $this->assertDatabaseHas(config('exponent-push-notifications.interests.database.table_name'), [
                 'key' => 'NotificationChannels.ExpoPushNotifications.Test.User.'.(new User)->getKey(),
-                'value' => $data['expo_token']
+                'value' => $data['expo_token'],
             ]);
         }
     }
@@ -180,7 +181,7 @@ class ExpoControllerTest extends TestCase
         if ($expoRepository instanceof ExpoDatabaseDriver) {
             $this->assertDatabaseMissing(config('exponent-push-notifications.interests.database.table_name'), [
                 'key' => 'NotificationChannels.ExpoPushNotifications.Test.User.'.(new User)->getKey(),
-                'value' => $data['expo_token']
+                'value' => $data['expo_token'],
             ]);
         }
     }
@@ -232,6 +233,7 @@ class ExpoControllerTest extends TestCase
 
         $this->assertEquals('failed', $response->status);
     }
+
     /**
      * Mocks a request for the ExpoController.
      *

--- a/tests/ExpoControllerTest.php
+++ b/tests/ExpoControllerTest.php
@@ -3,16 +3,14 @@
 namespace NotificationChannels\ExpoPushNotifications\Test;
 
 use ExponentPhpSDK\Expo;
-use ExponentPhpSDK\ExpoRegistrar;
-use ExponentPhpSDK\Repositories\ExpoFileDriver;
-use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Validation\Factory;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\Factory;
 use NotificationChannels\ExpoPushNotifications\ExpoChannel;
 use NotificationChannels\ExpoPushNotifications\Http\ExpoController;
-use PHPUnit\Framework\TestCase;
 
 class ExpoControllerTest extends TestCase
 {
@@ -134,7 +132,7 @@ class ExpoControllerTest extends TestCase
     }
 
     /**
-     * Mocks a request for the ExpoController
+     * Mocks a request for the ExpoController.
      *
      * @param $data
      *
@@ -163,6 +161,7 @@ class ExpoControllerTest extends TestCase
         $validator->shouldReceive('fails')->once()->andReturn($fails);
 
         Validator::swap($validation);
+
         return $validator;
     }
 }

--- a/tests/ExpoControllerTest.php
+++ b/tests/ExpoControllerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Test;
+
+use ExponentPhpSDK\Expo;
+use ExponentPhpSDK\ExpoRegistrar;
+use ExponentPhpSDK\Repositories\ExpoFileDriver;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Factory;
+use NotificationChannels\ExpoPushNotifications\ExpoChannel;
+use NotificationChannels\ExpoPushNotifications\Http\ExpoController;
+use PHPUnit\Framework\TestCase;
+
+class ExpoControllerTest extends TestCase
+{
+    /**
+     * @var ExpoChannel
+     */
+    protected $expoChannel;
+
+    /**
+     * @var ExpoController
+     */
+    protected $expoController;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->expoChannel = new ExpoChannel(Expo::normalSetup(), new Dispatcher());
+
+        $this->expoController = new ExpoController($this->expoChannel);
+
+        // We will fake an authenticated user
+        Auth::shouldReceive('user')->andReturn(new User());
+    }
+
+    public function tearDown()
+    {
+        \Mockery::close();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function aDeviceCanSubscribeToTheSystem()
+    {
+        // We will fake a request with the following data
+        $data = ['expo_token' => 'ExponentPushToken[fakeToken]'];
+        $request = $this->mockRequest($data);
+        $request->shouldReceive('get')->with('expo_token')->andReturn($data['expo_token']);
+
+        $this->mockValidator(false);
+
+        /** @var Request $request */
+        $response = $this->expoController->subscribe($request);
+        $response = json_decode($response->content());
+
+        // The response should contain a succeeded status
+        $this->assertEquals('succeeded', $response->status);
+        // The response should return the registered token
+        $this->assertEquals($data['expo_token'], $response->expo_token);
+    }
+
+    /** @test */
+    public function subscribeReturnsErrorResponseIfTokenInvalid()
+    {
+        // We will fake a request with no data
+        $request = $this->mockRequest([]);
+
+        $this->mockValidator(true);
+
+        /** @var Request $request */
+        $response = $this->expoController->subscribe($request);
+
+        // The response should contain a failed status
+        $this->assertEquals('failed', json_decode($response->content())->status);
+        // The response status should be 422
+        $this->assertEquals(422, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function subscribeReturnsErrorResponseIfExceptionIsThrown()
+    {
+        // We will fake a request with the following data
+        $data = ['expo_token' => 'ExponentPushToken[fakeToken]'];
+        $request = $this->mockRequest($data);
+        $request->shouldReceive('get')->andReturn($data['expo_token']);
+
+        $this->mockValidator(false);
+
+        $expo = \Mockery::mock(Expo::class);
+        $expo->shouldReceive('subscribe')->andThrow(\Exception::class);
+
+        /** @var Expo $expo */
+        $expoChannel = new ExpoChannel($expo, new Dispatcher());
+
+        /** @var Request $request */
+        $response = (new ExpoController($expoChannel))->subscribe($request);
+        $response = json_decode($response->content());
+
+        $this->assertEquals('failed', $response->status);
+    }
+
+    /** @test */
+    public function aDeviceCanUnsubscribeFromTheSystem()
+    {
+        // We will subscribe an interest to the server.
+        $token = 'ExponentPushToken[fakeToken]';
+        $interest = $this->expoChannel->interestName(new User());
+        $this->expoChannel->expo->subscribe($interest, $token);
+
+        $response = $this->expoController->unsubscribe();
+        $response = json_decode($response->content());
+
+        // The response should contain a deleted property with value true
+        $this->assertTrue($response->deleted);
+    }
+
+    /** @test */
+    public function unsubscribeReturnsErrorResponseIfExceptionIsThrown()
+    {
+        $expo = \Mockery::mock(Expo::class);
+        $expo->shouldReceive('unsubscribe')->andThrow(\Exception::class);
+
+        /** @var Expo $expo */
+        $response = (new ExpoController(new ExpoChannel($expo, new Dispatcher())))->unsubscribe();
+        $response = json_decode($response->content());
+
+        $this->assertEquals('failed', $response->status);
+    }
+
+    /**
+     * Mocks a request for the ExpoController
+     *
+     * @param $data
+     *
+     * @return \Mockery\MockInterface
+     */
+    private function mockRequest($data)
+    {
+        $request = \Mockery::mock(Request::class);
+        $request->shouldReceive('all')->andReturn($data);
+
+        return $request;
+    }
+
+    /**
+     * @param bool $fails
+     *
+     * @return \Mockery\MockInterface
+     */
+    private function mockValidator(bool $fails)
+    {
+        $validator = \Mockery::mock(\Illuminate\Validation\Validator::class);
+
+        $validation = \Mockery::mock(Factory::class);
+        $validation->shouldReceive('make')->once()->andReturn($validator);
+
+        $validator->shouldReceive('fails')->once()->andReturn($fails);
+
+        Validator::swap($validation);
+        return $validator;
+    }
+}
+
+class User
+{
+    public function getKey()
+    {
+        return 1;
+    }
+}

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -3,7 +3,6 @@
 namespace NotificationChannels\ExpoPushNotifications\Test;
 
 use Illuminate\Support\Arr;
-use PHPUnit\Framework\TestCase;
 use NotificationChannels\ExpoPushNotifications\ExpoMessage;
 
 class MessageTest extends TestCase

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -90,4 +90,12 @@ class MessageTest extends TestCase
 
         $this->assertEquals(60, Arr::get($this->message->toArray(), 'ttl'));
     }
+
+    /** @test */
+    public function itCanSetJSONData()
+    {
+        $this->message->setJsonData('{"name":"Aly"}');
+
+        $this->assertEquals('{"name":"Aly"}', Arr::get($this->message->toArray(), 'data'));
+    }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -3,8 +3,8 @@
 namespace NotificationChannels\ExpoPushNotifications\Test;
 
 use Illuminate\Support\Arr;
-use NotificationChannels\ExpoPushNotifications\ExpoMessage;
 use PHPUnit\Framework\TestCase;
+use NotificationChannels\ExpoPushNotifications\ExpoMessage;
 
 class MessageTest extends TestCase
 {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Test;
+
+use Illuminate\Support\Arr;
+use NotificationChannels\ExpoPushNotifications\ExpoMessage;
+use PHPUnit\Framework\TestCase;
+
+class MessageTest extends TestCase
+{
+    /**
+     * @var ExpoMessage
+     */
+    protected $message;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->message = new ExpoMessage();
+    }
+
+    /** @test */
+    public function itProvidesACreateMethod()
+    {
+        $message = ExpoMessage::create('myMessage');
+
+        $this->assertEquals('myMessage', Arr::get($message->toArray(), 'body'));
+    }
+
+    /** @test */
+    public function itCanAcceptsABodyWhenConstructingAMessage()
+    {
+        $message = new ExpoMessage('myMessage');
+
+        $this->assertEquals('myMessage', Arr::get($message->toArray(), 'body'));
+    }
+
+    /** @test */
+    public function itProvidesACreateMethodThatAcceptsAMessageBody()
+    {
+        $message = new ExpoMessage('myMessage');
+
+        $this->assertEquals('myMessage', Arr::get($message->toArray(), 'body'));
+    }
+
+    /** @test */
+    public function itSetsABodyToTheMessage()
+    {
+        $this->message->body('myMessage');
+
+        $this->assertEquals('myMessage', Arr::get($this->message->toArray(), 'body'));
+    }
+
+    /** @test */
+    public function itSetsADefaultSound()
+    {
+        $this->assertEquals('default', Arr::get($this->message->toArray(), 'sound'));
+    }
+
+    /** @test */
+    public function itCanMuteSound()
+    {
+        $this->message->disableSound();
+
+        $this->assertNull(Arr::get($this->message->toArray(), 'sound'));
+    }
+
+    /** @test */
+    public function itCanEnableSound()
+    {
+        $this->message->disableSound();
+        $this->message->enableSound();
+
+        $this->assertNotNull(Arr::get($this->message->toArray(), 'sound'));
+    }
+
+    /** @test */
+    public function itCanSetTheBadge()
+    {
+        $this->message->badge(5);
+
+        $this->assertEquals(5, Arr::get($this->message->toArray(), 'badge'));
+    }
+
+    /** @test */
+    public function itCanSetTimeToLive()
+    {
+        $this->message->setTtl(60);
+
+        $this->assertEquals(60, Arr::get($this->message->toArray(), 'ttl'));
+    }
+}

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -92,6 +92,14 @@ class MessageTest extends TestCase
     }
 
     /** @test */
+    public function itCanSetChannelId()
+    {
+        $this->message->setChannelId('some-channel');
+
+        $this->assertEquals('some-channel', Arr::get($this->message->toArray(), 'channelId'));
+    }
+
+    /** @test */
     public function itCanSetJSONData()
     {
         $this->message->setJsonData('{"name":"Aly"}');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace NotificationChannels\ExpoPushNotifications\Test;
+
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use NotificationChannels\ExpoPushNotifications\ExpoPushNotificationsServiceProvider;
+
+abstract class TestCase extends OrchestraTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            ExpoPushNotificationsServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application   $app
+     *
+     * @return void
+     */
+    public function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'sqlite');
+
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => $this->getDatabaseDirectory().'/database.sqlite',
+            'prefix' => '',
+        ]);
+
+        $app['config']->set('auth.providers.users.model', User::class);
+    }
+
+    /**
+     * Sets up the database.
+     *
+     * @return void
+     */
+    protected function setUpDatabase()
+    {
+        $this->resetDatabase();
+
+        $this->createExponentPushNotificationInterestsTable();
+    }
+
+    /**
+     * Drops the database.
+     *
+     * @return void
+     */
+    protected function resetDatabase()
+    {
+        file_put_contents(__DIR__.'/temp'.'/database.sqlite', null);
+    }
+
+    /**
+     * Creates the interests table.
+     *
+     * @return void
+     */
+    protected function createExponentPushNotificationInterestsTable()
+    {
+        include_once '__DIR__'.'/../migrations/create_exponent_push_notification_interests_table.php.stub';
+
+        (new \CreateExponentPushNotificationInterestsTable())->up();
+    }
+
+    /**
+     * Gets the directory path for the testing database.
+     *
+     * @return string
+     */
+    public function getDatabaseDirectory(): string
+    {
+        return __DIR__.'/temp';
+    }
+}

--- a/tests/temp/.gitignore
+++ b/tests/temp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
`fire` method on Illuminate\Events\Dispatcher was an alias of `dispatch` method and has been removed in Laravel 5.8.
`dispatch` method has been introduced since Laravel 5.4
